### PR TITLE
Removed tenant Id from API strategy and WebAppStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ app.use(passport.initialize());
 // App ID service instance. In this case App ID configuration will be obtained
 // using VCAP_SERVICES environment variable.
 passport.use(new APIStrategy({
-	oauthServerUrl: "{oauth-server-url}",
-	tenantId: "{tenant-id}"
+	oauthServerUrl: "{oauth-server-url}"
 }));
 
 // Declare the API you want to protect

--- a/lib/strategies/api-strategy.js
+++ b/lib/strategies/api-strategy.js
@@ -33,10 +33,7 @@ function ApiStrategy(options) {
 	logger.debug("Initializing");
 	options = options || {};
 	this.name = ApiStrategy.STRATEGY_NAME;
-	this.serviceConfig = new ServiceUtil.loadConfig('APIStrategy', [
-		constants.TENANT_ID,
-		constants.OAUTH_SERVER_URL
-	], options);
+	this.serviceConfig = new ServiceUtil.loadConfig('APIStrategy', [constants.OAUTH_SERVER_URL], options);
 	PublicKeyUtil.setPublicKeysEndpoint(this.serviceConfig.getOAuthServerUrl());
 }
 

--- a/lib/strategies/api-strategy.js
+++ b/lib/strategies/api-strategy.js
@@ -73,7 +73,7 @@ ApiStrategy.prototype.authenticate = function (req, options) {
 	var accessTokenString = authHeaderComponents[1];
 
 	// Decode and validate access_token
-	TokenUtil.decodeAndValidate(accessTokenString, self.serviceConfig, false).then(function (accessToken) {
+	TokenUtil.decodeAndValidate(accessTokenString).then(function (accessToken) {
 		if (!accessToken) {
 			logger.warn("Invalid access_token");
 			return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
@@ -108,7 +108,7 @@ ApiStrategy.prototype.authenticate = function (req, options) {
 		var identityToken;
 		if (authHeaderComponents.length === 3) {
 			identityTokenString = authHeaderComponents[2];
-			TokenUtil.decodeAndValidate(identityTokenString, self.serviceConfig, false).then(function (identityToken) {
+			TokenUtil.decodeAndValidate(identityTokenString).then(function (identityToken) {
 				if (identityToken) {
 					req.appIdAuthorizationContext.identityToken = identityTokenString;
 					req.appIdAuthorizationContext.identityTokenPayload = identityToken;

--- a/lib/strategies/api-strategy.js
+++ b/lib/strategies/api-strategy.js
@@ -43,31 +43,31 @@ function ApiStrategy(options) {
 ApiStrategy.STRATEGY_NAME = STRATEGY_NAME;
 ApiStrategy.DEFAULT_SCOPE = "appid_default";
 
-ApiStrategy.prototype.authenticate = function(req, options) {
+ApiStrategy.prototype.authenticate = function (req, options) {
 	var self = this;
 	logger.debug("authenticate");
 	options = options || {};
 	var requiredScope = ApiStrategy.DEFAULT_SCOPE;
-	if (options.scope){
+	if (options.scope) {
 		requiredScope += " " + options.scope;
 	}
 
 	// Retrieve authorization header from request
 	var authHeader = req.header(AUTHORIZATION_HEADER);
-	if (!authHeader){
+	if (!authHeader) {
 		logger.warn("Authorization header not found");
 		return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
 	}
 
 	// Validate that first header component is Bearer
 	var authHeaderComponents = authHeader.split(" ");
-	if (authHeaderComponents[0].indexOf(BEARER) !== 0){
+	if (authHeaderComponents[0].indexOf(BEARER) !== 0) {
 		logger.warn("Malformed authorization header");
 		return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
 	}
 
 	// Validate header has exactly 2 or 3 components (Bearer, access_token, [id_token])
-	if (authHeaderComponents.length !== 2 && authHeaderComponents.length !== 3){
+	if (authHeaderComponents.length !== 2 && authHeaderComponents.length !== 3) {
 		logger.warn("Malformed authorization header");
 		return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
 	}
@@ -76,62 +76,62 @@ ApiStrategy.prototype.authenticate = function(req, options) {
 	var accessTokenString = authHeaderComponents[1];
 
 	// Decode and validate access_token
-    TokenUtil.decodeAndValidate(accessTokenString, self.serviceConfig).then(function(accessToken) {
-        if (!accessToken) {
-            logger.warn("Invalid access_token");
-            return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
-        }
-
-        // Validate token contains required scopes
-        var requiredScopeElements = requiredScope.split(" ");
-        var suppliedScopeElements = accessToken.scope.split(" ");
-        for (var i = 0; i < requiredScopeElements.length; i++) {
-            var requiredScopeElement = requiredScopeElements[i];
-            var found = false;
-            for (var j = 0; j < suppliedScopeElements.length; j++) {
-                var suppliedScopeElement = suppliedScopeElements[j];
-                if (requiredScopeElement === suppliedScopeElement) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                logger.warn("access_token does not contain required scope. Expected ::", requiredScope, " Received ::", accessToken.scope);
-                return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INSUFFICIENT_SCOPE), 401);
-            }
-        }
-
-        req.appIdAuthorizationContext = {
-            accessToken: accessTokenString,
-            accessTokenPayload: accessToken
-        };
-
-        // Decode and validate id_token
-        var identityTokenString;
-        var identityToken;
-        if (authHeaderComponents.length === 3) {
-            identityTokenString = authHeaderComponents[2];
-            TokenUtil.decodeAndValidate(identityTokenString, self.serviceConfig).then(function(identityToken) {
-                if (identityToken) {
-                	req.appIdAuthorizationContext.identityToken = identityTokenString;
-                	req.appIdAuthorizationContext.identityTokenPayload = identityToken;
-                } else {
-                    logger.warn("Invalid identity_token. Proceeding with access_token only");
-                }
-							logger.debug("authentication success");
-							return self.success(identityToken || null);
-            }).catch (function (err) {
-							logger.debug("authentication failed due to invalid identity token");
-							return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
-            });
-        } else {
-            logger.debug("authentication success: identity_token not found. Proceeding with access_token only");
-            return self.success(identityToken || null);
-        }
-    }).catch (function (err) {
-			logger.debug("authentication failed due to invalid access token");
+	TokenUtil.decodeAndValidate(accessTokenString, self.serviceConfig, false).then(function (accessToken) {
+		if (!accessToken) {
+			logger.warn("Invalid access_token");
 			return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
-    });
+		}
+
+		// Validate token contains required scopes
+		var requiredScopeElements = requiredScope.split(" ");
+		var suppliedScopeElements = accessToken.scope.split(" ");
+		for (var i = 0; i < requiredScopeElements.length; i++) {
+			var requiredScopeElement = requiredScopeElements[i];
+			var found = false;
+			for (var j = 0; j < suppliedScopeElements.length; j++) {
+				var suppliedScopeElement = suppliedScopeElements[j];
+				if (requiredScopeElement === suppliedScopeElement) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				logger.warn("access_token does not contain required scope. Expected ::", requiredScope, " Received ::", accessToken.scope);
+				return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INSUFFICIENT_SCOPE), 401);
+			}
+		}
+
+		req.appIdAuthorizationContext = {
+			accessToken: accessTokenString,
+			accessTokenPayload: accessToken
+		};
+
+		// Decode and validate id_token
+		var identityTokenString;
+		var identityToken;
+		if (authHeaderComponents.length === 3) {
+			identityTokenString = authHeaderComponents[2];
+			TokenUtil.decodeAndValidate(identityTokenString, self.serviceConfig, false).then(function (identityToken) {
+				if (identityToken) {
+					req.appIdAuthorizationContext.identityToken = identityTokenString;
+					req.appIdAuthorizationContext.identityTokenPayload = identityToken;
+				} else {
+					logger.warn("Invalid identity_token. Proceeding with access_token only");
+				}
+				logger.debug("authentication success");
+				return self.success(identityToken || null);
+			}).catch(function (err) {
+				logger.debug("authentication failed due to invalid identity token");
+				return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
+			});
+		} else {
+			logger.debug("authentication success: identity_token not found. Proceeding with access_token only");
+			return self.success(identityToken || null);
+		}
+	}).catch(function (err) {
+		logger.debug("authentication failed due to invalid access token");
+		return self.fail(buildWwwAuthenticateHeader(requiredScope, ERROR.INVALID_TOKEN), 401);
+	});
 
 	// .success(user, info) - call on auth success. user=object, info=object
 	// .fail(challenge, status) - call on auth failure. challenge=string, status=int
@@ -140,9 +140,9 @@ ApiStrategy.prototype.authenticate = function(req, options) {
 	// .error(err) - error during strategy processing. err=Error obj
 };
 
-function buildWwwAuthenticateHeader(scope, error){
+function buildWwwAuthenticateHeader(scope, error) {
 	var msg = BEARER + " scope=\"" + scope + "\"";
-	if (error){
+	if (error) {
 		msg += ", error=\"" + error + "\"";
 	}
 	return msg;

--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -424,8 +424,8 @@ function retrieveTokens(formData, strategy) {
 			};
 
 			Promise.all([
-				TokenUtil.decodeAndValidate(accessTokenString, serviceConfig, false),
-				TokenUtil.decodeAndValidate(identityTokenString, serviceConfig, false)]).then(function (tokens) {
+				TokenUtil.decodeAndValidate(accessTokenString),
+				TokenUtil.decodeAndValidate(identityTokenString)]).then(function (tokens) {
 				if (tokens.length < 2 || !tokens[0] || !tokens[1]) {
 					throw new Error("Invalid access/id token");
 				}

--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -423,8 +423,9 @@ function retrieveTokens(formData, strategy) {
 				refreshToken: refreshToken
 			};
 
-			Promise.all([TokenUtil.decodeAndValidate(accessTokenString, serviceConfig),
-				TokenUtil.decodeAndValidate(identityTokenString, serviceConfig)]).then(function (tokens) {
+			Promise.all([
+				TokenUtil.decodeAndValidate(accessTokenString, serviceConfig, false),
+				TokenUtil.decodeAndValidate(identityTokenString, serviceConfig, false)]).then(function (tokens) {
 				if (tokens.length < 2 || !tokens[0] || !tokens[1]) {
 					throw new Error("Invalid access/id token");
 				}

--- a/lib/token-manager/token-manager.js
+++ b/lib/token-manager/token-manager.js
@@ -27,7 +27,6 @@ function TokenManager(options) {
 	logger.debug("Initializing token manager");
 	this.serviceConfig = new ServiceUtil.loadConfig('TokenManager', [
 		constants.CLIENT_ID,
-		constants.TENANT_ID,
 		constants.SECRET,
 		constants.OAUTH_SERVER_URL
 	], options);
@@ -106,7 +105,7 @@ function getTokens(tokenEndpoint, clientId, secret, grant_type, scope, assertion
 
 function validateToken(tokenType, token, serviceConfig) {
 	logger.debug(`Validating ${tokenType} token`);
-	return TokenUtil.decodeAndValidate(token, serviceConfig).then((validatedToken) => {
+	return TokenUtil.decodeAndValidate(token).then((validatedToken) => {
 		if (!validatedToken) {
 			logger.error(`Invalid ${tokenType} token`);
 			throw Error(`Invalid ${tokenType} token`);

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -23,17 +23,17 @@ const APPID_ALLOW_EXPIRED_TOKENS = "APPID_ALLOW_EXPIRED_TOKENS";
 const alg = "RS256";
 const bytes = 20;
 
-module.exports = (function(){
+module.exports = (function () {
 	logger.debug("Initializing");
 
-	function decode(tokenString, getHeader){
-		var decodedToken = jwt.decode(tokenString,{complete: getHeader});
+	function decode(tokenString, getHeader) {
+		var decodedToken = jwt.decode(tokenString, { complete: getHeader });
 		return decodedToken;
 	}
 
-	function decodeAndValidate(tokenString,serviceConfig) {
+	function decodeAndValidate(tokenString, serviceConfig, validateTenantId=true) {
 		var deferred = Q.defer();
-		if(!serviceConfig || serviceConfig ===""){
+		if (!serviceConfig || serviceConfig === "") {
 			deferred.reject("Invalid service configuration");
 			return deferred.promise;
 		}
@@ -52,10 +52,14 @@ module.exports = (function(){
 
 		publicKeyUtil.getPublicKeyPemByKid(tokenHeader.kid).then(function (publicKeyPem) {
 			try {
-				var decodedToken = jwt.verify(tokenString, publicKeyPem, { algorithms: alg, ignoreExpiration: allowExpiredTokens, json: true});
-				if (decodedToken.tenant !== serviceConfig.getTenantId()) {
+				var decodedToken = jwt.verify(tokenString, publicKeyPem, {
+					algorithms: alg,
+					ignoreExpiration: allowExpiredTokens,
+					json: true
+				});
+				if (validateTenantId && decodedToken.tenant !== serviceConfig.getTenantId()) {
 					deferred.reject("JWT error, invalid tenantId");
-				}else {
+				} else {
 					deferred.resolve(decodedToken);
 				}
 			} catch (err) {
@@ -87,5 +91,5 @@ module.exports = (function(){
 		return crypto.randomBytes(bytes).toString();
 	}
 
-	return {decodeAndValidate, decode, validateIssAndAud, getRandomNumber};
+	return { decodeAndValidate, decode, validateIssAndAud, getRandomNumber };
 }());

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -31,7 +31,7 @@ module.exports = (function () {
 		return decodedToken;
 	}
 
-	function decodeAndValidate(tokenString, serviceConfig, validateTenantId=true) {
+	function decodeAndValidate(tokenString, serviceConfig, validateTenantId = true) {
 		var deferred = Q.defer();
 		if (!serviceConfig || serviceConfig === "") {
 			deferred.reject("Invalid service configuration");

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -31,12 +31,8 @@ module.exports = (function () {
 		return decodedToken;
 	}
 
-	function decodeAndValidate(tokenString, serviceConfig, validateTenantId = true) {
+	function decodeAndValidate(tokenString) {
 		var deferred = Q.defer();
-		if (!serviceConfig || serviceConfig === "") {
-			deferred.reject("Invalid service configuration");
-			return deferred.promise;
-		}
 
 		var allowExpiredTokens = process.env.APPID_ALLOW_EXPIRED_TOKENS || false;
 		if (allowExpiredTokens) {
@@ -57,11 +53,7 @@ module.exports = (function () {
 					ignoreExpiration: allowExpiredTokens,
 					json: true
 				});
-				if (validateTenantId && decodedToken.tenant !== serviceConfig.getTenantId()) {
-					deferred.reject("JWT error, invalid tenantId");
-				} else {
-					deferred.resolve(decodedToken);
-				}
+				deferred.resolve(decodedToken);
 			} catch (err) {
 				logger.debug("JWT error ::", err.message);
 				deferred.reject(err);

--- a/samples/api-app-sample-server.js
+++ b/samples/api-app-sample-server.js
@@ -24,8 +24,7 @@ app.use(helmet());
 app.use(passport.initialize());
 
 passport.use(new APIStrategy({
-	oauthServerUrl: "{oauth-server-url}",
-	tenantId: "{tenant-id}"
+	oauthServerUrl: "{oauth-server-url}"
 }));
 
 app.get("/api/protected",

--- a/samples/custom-identity-app-sample-server.js
+++ b/samples/custom-identity-app-sample-server.js
@@ -39,7 +39,6 @@ const PROTECTED_URL = '/protected';
 const APPID_AUTH_CONTEXT = 'AppID_Auth_context';
 
 const tokenManager = new AppID.TokenManager({
-	tenantId: '{tenant-id}',
 	clientId: '{client-id}',
 	secret: '{secret}',
 	oauthServerUrl: '{oauth-server-url}',

--- a/test/api-strategy-test.js
+++ b/test/api-strategy-test.js
@@ -15,42 +15,41 @@ const chai = require("chai");
 const assert = chai.assert;
 const proxyquire = require("proxyquire");
 
-describe("/lib/strategies/api-strategy", function(){
+describe("/lib/strategies/api-strategy", function () {
 	console.log("Loading api-strategy-test.js");
 
 	var APIStrategy;
 	var apiStrategy;
 
-	before(function(){
+	before(function () {
 		APIStrategy = proxyquire("../lib/strategies/api-strategy", {
 			"../utils/public-key-util": require("./mocks/public-key-util-mock"),
 			"../utils/token-util": require("./mocks/token-util-mock")
 		});
 		apiStrategy = new APIStrategy({
-			oauthServerUrl: "serverUrl",
-			tenantId: "tenantId"
+			oauthServerUrl: "serverUrl"
 		});
 	});
 
-	describe("#properties", function(){
-		it("Should have all properties", function(){
+	describe("#properties", function () {
+		it("Should have all properties", function () {
 			assert.isFunction(APIStrategy);
 			assert.equal(APIStrategy.STRATEGY_NAME, "appid-api-strategy");
 			assert.equal(APIStrategy.DEFAULT_SCOPE, "appid_default");
 		});
 	});
 
-	describe("#authenticate()", function(){
+	describe("#authenticate()", function () {
 
-		it("Should fail returning both default and custom scopes", function(done){
-			apiStrategy.fail = function(msg, status){
+		it("Should fail returning both default and custom scopes", function (done) {
+			apiStrategy.fail = function (msg, status) {
 				assert.equal(msg, "Bearer scope=\"appid_default custom_scope\", error=\"invalid_token\"");
 				assert.equal(status, 401);
 				done();
 			};
 
 			apiStrategy.authenticate({
-				header: function(){
+				header: function () {
 					return null;
 				}
 			}, {
@@ -58,80 +57,80 @@ describe("/lib/strategies/api-strategy", function(){
 			});
 		});
 
-		it("Should fail when there's no access token", function(done){
-			apiStrategy.fail = function(msg, status){
+		it("Should fail when there's no access token", function (done) {
+			apiStrategy.fail = function (msg, status) {
 				assert.equal(msg, 'Bearer scope="appid_default", error="invalid_token"');
 				assert.equal(status, 401);
 				done();
-			}
+			};
 
 			apiStrategy.authenticate({
-				header: function(){
+				header: function () {
 					return null;
 				}
 			});
 		});
 
-		it("Should fail when access token is not Bearer", function(done){
-			apiStrategy.fail = function(msg, status){
+		it("Should fail when access token is not Bearer", function (done) {
+			apiStrategy.fail = function (msg, status) {
 				assert.equal(msg, 'Bearer scope="appid_default", error="invalid_token"');
 				assert.equal(status, 401);
 				done()
-			}
+			};
 			apiStrategy.authenticate({
-				header: function(){
+				header: function () {
 					return "Some Weird Stuff";
 				}
 			});
 		});
 
-		it("Should fail when access token is malformed", function(done){
-			apiStrategy.fail = function(msg, status){
+		it("Should fail when access token is malformed", function (done) {
+			apiStrategy.fail = function (msg, status) {
 				assert.equal(msg, 'Bearer scope="appid_default", error="invalid_token"');
 				assert.equal(status, 401);
 				done()
-			}
+			};
 			apiStrategy.authenticate({
-				header: function(){
+				header: function () {
 					return "Bearer asd asd asd";
 				}
 			});
 		});
 
-		it("Should fail when access token cannot be decoded", function(done){
-			apiStrategy.fail = function(msg, status){
+		it("Should fail when access token cannot be decoded", function (done) {
+			apiStrategy.fail = function (msg, status) {
 				assert.equal(msg, 'Bearer scope="appid_default", error="invalid_token"');
 				assert.equal(status, 401);
 				done()
 			}
 			apiStrategy.authenticate({
-				header: function(){
+				header: function () {
 					return "Bearer invalid_token";
 				}
 			});
 		});
 
-		it("Should fail when access token scope does not contain required scope", function(done){
-			apiStrategy.fail = function(msg, status){
+		it("Should fail when access token scope does not contain required scope", function (done) {
+			apiStrategy.fail = function (msg, status) {
 				assert.equal(msg, 'Bearer scope="appid_default", error="insufficient_scope"');
 				assert.equal(status, 401);
 				done()
 			}
 			apiStrategy.authenticate({
-				header: function(){
+				header: function () {
 					return "Bearer bad_scope";
 				}
 			});
 		});
 
-		it("Should not fail when id token is not present", function(done){
+		it("Should not fail when id token is not present", function (done) {
 			var req = {
-				header: function(){
+				header: function () {
 					return "Bearer access_token";
 				}
 			};
 
-			apiStrategy.success = function(idToken){
+			apiStrategy.success = function (idToken) {
 				assert.isNull(idToken);
 				assert.isObject(req.appIdAuthorizationContext);
 
@@ -144,19 +143,19 @@ describe("/lib/strategies/api-strategy", function(){
 				assert.isUndefined(req.appIdAuthorizationContext.identityTokenPayload);
 
 				done()
-			}
+			};
 
 			apiStrategy.authenticate(req);
 		});
 
-		it("Should not fail when id token is invalid", function(done){
+		it("Should not fail when id token is invalid", function (done) {
 			var req = {
-				header: function(){
+				header: function () {
 					return "Bearer access_token invalid_token";
 				}
 			};
 
-			apiStrategy.success = function(idToken){
+			apiStrategy.success = function (idToken) {
 				assert.isNull(idToken);
 				assert.isObject(req.appIdAuthorizationContext);
 
@@ -169,20 +168,20 @@ describe("/lib/strategies/api-strategy", function(){
 				assert.isUndefined(req.appIdAuthorizationContext.identityTokenPayload);
 
 				done()
-			}
+			};
 
 			apiStrategy.authenticate(req);
 		});
 
 
-		it("Should succeed when valid access and id tokens are present", function(done){
+		it("Should succeed when valid access and id tokens are present", function (done) {
 			var req = {
-				header: function(){
+				header: function () {
 					return "Bearer access_token id_token";
 				}
 			};
 
-			apiStrategy.success = function(idToken){
+			apiStrategy.success = function (idToken) {
 				assert.isObject(req.appIdAuthorizationContext);
 
 				assert.isString(req.appIdAuthorizationContext.accessToken);
@@ -199,7 +198,7 @@ describe("/lib/strategies/api-strategy", function(){
 
 				assert.equal(idToken.scope, "appid_default");
 				done()
-			}
+			};
 
 			apiStrategy.authenticate(req);
 		});

--- a/test/api-strategy-test.js
+++ b/test/api-strategy-test.js
@@ -28,8 +28,7 @@ describe("/lib/strategies/api-strategy", function(){
 		});
 		apiStrategy = new APIStrategy({
 			oauthServerUrl: "serverUrl",
-			tenantId: "tenantId",
-			clientId: "clientId"
+			tenantId: "tenantId"
 		});
 	});
 

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -19,14 +19,14 @@ const proxyquire = require("proxyquire");
 const constants = require("./mocks/constants");
 
 
-describe("/lib/utils/token-util", function(){
+describe("/lib/utils/token-util", function () {
 	console.log("Loading token-util-test.js");
 	var TokenUtil;
 	var ServiceConfig;
 	var serviceConfig;
 	var Config;
 
-	before(function(){
+	before(function () {
 		TokenUtil = proxyquire("../lib/utils/token-util", {
 			"./public-key-util": require("./mocks/public-key-util-mock")
 		});
@@ -53,89 +53,99 @@ describe("/lib/utils/token-util", function(){
 		};
 	});
 
-	describe("#decodeAndValidate()", function(){
-		it("Should fail since service configuration is not defined", function(){
+	describe("#decodeAndValidate()", function () {
+		it("Should fail since service configuration is not defined", function () {
 			return expect(TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN)).to.be.rejectedWith("Invalid service configuration");
 		});
 
-		it("Should fail since token is expired", function(){
-			return expect(TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN,serviceConfig)).to.be.rejectedWith("jwt expired");
+		it("Should fail since token is expired", function () {
+			return expect(TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN, serviceConfig)).to.be.rejectedWith("jwt expired");
 		});
 
-		it("Should succeed since APPID_ALLOW_EXPIRED_TOKENS=true", function(){
+		it("Should succeed since APPID_ALLOW_EXPIRED_TOKENS=true", function () {
 			process.env[constants.APPID_ALLOW_EXPIRED_TOKENS] = true;
-			TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN,serviceConfig).then(function (decodedToken) {
+			TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN, serviceConfig).then(function (decodedToken) {
 				assert.isObject(decodedToken);
 			});
 		});
 
-		it("Should fail since token is malformed", function(){
+		it("Should fail since token is malformed", function () {
 			process.env[constants.APPID_ALLOW_EXPIRED_TOKENS] = true;
-			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN,serviceConfig)).to.be.rejectedWith("invalid algorithm");
+			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN, serviceConfig)).to.be.rejectedWith("invalid algorithm");
 		});
 
-		it("Should fail since header is empty in token", function(){
+		it("Should fail since header is empty in token", function () {
 			process.env[constants.APPID_ALLOW_EXPIRED_TOKENS] = true;
-			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN_WITHOUTHEADER,serviceConfig)).to.be.rejectedWith("JWT error, can not decode token");
+			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN_WITHOUTHEADER, serviceConfig)).to.be.rejectedWith("JWT error, can not decode token");
 		});
 
-		it("Should fail since tenantId is different", function(){
+		it("Should fail since tenantId is different", function () {
 			serviceConfig.tenantId = "abcdef";
-			return expect(TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN,new ServiceConfig({
+			return expect(TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, new ServiceConfig({
 				oauthServerUrl: constants.SERVER_URL,
 				tenantId: "4dba9430-54e6-4cf2-a516"
 			}))).to.be.rejectedWith("JWT error, invalid tenantId");
 		});
 
-		it("Should succeed since token is valid", function(){
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN,serviceConfig).then(function (decodedToken) {
+		it("Should succeed if there is no tenantId validation", function () {
+			serviceConfig.tenantId = "abcdef";
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, new ServiceConfig({
+				oauthServerUrl: constants.SERVER_URL,
+				tenantId: "4dba9430-54e6-4cf2-a516"
+			}), false).then(function (decodedToken) {
 				assert.isObject(decodedToken);
 			});
 		});
 
-		it("Token validation success", function(){
-			var config = new Config({
+		it("Should succeed since token is valid", function () {
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, serviceConfig).then(function (decodedToken) {
+				assert.isObject(decodedToken);
+			});
+		});
+
+		it("Token validation success", function () {
+			const config = new Config({
 				tenantId: constants.TENANTID,
 				clientId: constants.CLIENTID,
 				secret: "secret",
 				oauthServerUrl: constants.SERVER_URL,
 				redirectUri: "redirectUri"
 			});
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN,config).then(function (decodedToken) {
-				assert(TokenUtil.validateIssAndAud(decodedToken,config),true);
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, config).then(function (decodedToken) {
+				assert(TokenUtil.validateIssAndAud(decodedToken, config), true);
 			});
 		});
 
-		it("Token validation failed, invalid clientid ", function(){
-			var config = new Config({
+		it("Token validation failed, invalid clientid ", function () {
+			const config = new Config({
 				tenantId: constants.TENANTID,
 				clientId: "clientId",
 				secret: "secret",
 				oauthServerUrl: constants.SERVER_URL,
 				redirectUri: "redirectUri"
 			});
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN,config).then(function (decodedToken) {
-				assert(TokenUtil.validateIssAndAud(decodedToken,config),false);
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, config).then(function (decodedToken) {
+				assert(TokenUtil.validateIssAndAud(decodedToken, config), false);
 			});
 		});
 
-		it("Token validation failed, invalid serverurl", function(){
-			var config = new Config({
+		it("Token validation failed, invalid serverurl", function () {
+			const config = new Config({
 				tenantId: constants.TENANTID,
 				clientId: constants.CLIENTID,
 				secret: "secret",
 				oauthServerUrl: "http://mobileclientaccess/",
 				redirectUri: "redirectUri"
 			});
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN,config).then(function (decodedToken) {
-				assert(TokenUtil.validateIssAndAud(decodedToken,config),false);
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, config).then(function (decodedToken) {
+				assert(TokenUtil.validateIssAndAud(decodedToken, config), false);
 			});
 		});
 	});
 
-	describe("#decode()", function(){
-		it("Should return a valid decoded token", function(){
-			var decodedToken = TokenUtil.decode(constants.ACCESS_TOKEN);
+	describe("#decode()", function () {
+		it("Should return a valid decoded token", function () {
+			const decodedToken = TokenUtil.decode(constants.ACCESS_TOKEN);
 			assert.isObject(decodedToken);
 			assert.property(decodedToken, "iss");
 			assert.property(decodedToken, "tenant");

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -54,51 +54,30 @@ describe("/lib/utils/token-util", function () {
 	});
 
 	describe("#decodeAndValidate()", function () {
-		it("Should fail since service configuration is not defined", function () {
-			return expect(TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN)).to.be.rejectedWith("Invalid service configuration");
-		});
 
 		it("Should fail since token is expired", function () {
-			return expect(TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN, serviceConfig)).to.be.rejectedWith("jwt expired");
+			return expect(TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN)).to.be.rejectedWith("jwt expired");
 		});
 
 		it("Should succeed since APPID_ALLOW_EXPIRED_TOKENS=true", function () {
 			process.env[constants.APPID_ALLOW_EXPIRED_TOKENS] = true;
-			TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN, serviceConfig).then(function (decodedToken) {
+			TokenUtil.decodeAndValidate(constants.EXPIRED_ACCESS_TOKEN).then(function (decodedToken) {
 				assert.isObject(decodedToken);
 			});
 		});
 
 		it("Should fail since token is malformed", function () {
 			process.env[constants.APPID_ALLOW_EXPIRED_TOKENS] = true;
-			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN, serviceConfig)).to.be.rejectedWith("invalid algorithm");
+			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN)).to.be.rejectedWith("invalid algorithm");
 		});
 
 		it("Should fail since header is empty in token", function () {
 			process.env[constants.APPID_ALLOW_EXPIRED_TOKENS] = true;
-			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN_WITHOUTHEADER, serviceConfig)).to.be.rejectedWith("JWT error, can not decode token");
-		});
-
-		it("Should fail since tenantId is different", function () {
-			serviceConfig.tenantId = "abcdef";
-			return expect(TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, new ServiceConfig({
-				oauthServerUrl: constants.SERVER_URL,
-				tenantId: "4dba9430-54e6-4cf2-a516"
-			}))).to.be.rejectedWith("JWT error, invalid tenantId");
-		});
-
-		it("Should succeed if there is no tenantId validation", function () {
-			serviceConfig.tenantId = "abcdef";
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, new ServiceConfig({
-				oauthServerUrl: constants.SERVER_URL,
-				tenantId: "4dba9430-54e6-4cf2-a516"
-			}), false).then(function (decodedToken) {
-				assert.isObject(decodedToken);
-			});
+			return expect(TokenUtil.decodeAndValidate(constants.MALFORMED_ACCESS_TOKEN_WITHOUTHEADER)).to.be.rejectedWith("JWT error, can not decode token");
 		});
 
 		it("Should succeed since token is valid", function () {
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, serviceConfig).then(function (decodedToken) {
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
 				assert.isObject(decodedToken);
 			});
 		});
@@ -111,7 +90,7 @@ describe("/lib/utils/token-util", function () {
 				oauthServerUrl: constants.SERVER_URL,
 				redirectUri: "redirectUri"
 			});
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, config).then(function (decodedToken) {
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
 				assert(TokenUtil.validateIssAndAud(decodedToken, config), true);
 			});
 		});
@@ -124,7 +103,7 @@ describe("/lib/utils/token-util", function () {
 				oauthServerUrl: constants.SERVER_URL,
 				redirectUri: "redirectUri"
 			});
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, config).then(function (decodedToken) {
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
 				assert(TokenUtil.validateIssAndAud(decodedToken, config), false);
 			});
 		});
@@ -137,7 +116,7 @@ describe("/lib/utils/token-util", function () {
 				oauthServerUrl: "http://mobileclientaccess/",
 				redirectUri: "redirectUri"
 			});
-			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN, config).then(function (decodedToken) {
+			TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
 				assert(TokenUtil.validateIssAndAud(decodedToken, config), false);
 			});
 		});


### PR DESCRIPTION
* Removed tenant Id as a requirement for initializing API strategy.
* Removed tenant Id validation from API strategy.
* Removed tenant Id validation from Web App strategy.
* Removed tenant Id validation from Custom Identity.

The tenant Id was redundant as it was already present in the OAuthServerURL.