### PR TITLE
Remove "signin" from the "Self Service" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Note:
 
 ### Self Service APIs
 
-Use the self service manager when you want to control the UI for the sign-in, sign-up, forgot password, changeDetail and change password flows.
+Use the self service manager when you want to control the UI for the sign-up, forgot password, changeDetail and change password flows.
 The selfServiceManager can be init with the following options:
 
 * iamApiKey: If supplied, it will be used to get iamToken before every request of the selfServiceManager.


### PR DESCRIPTION
Since the SelfService manager doesn't handle the sign-in workflow, I figured it would make sense to remove it from the Self Service APIs section of the readme file.

Relevant issue : https://github.com/ibm-cloud-security/appid-serversdk-nodejs/issues/173