### PR TITLE
Migrate the deprecated request library to Gotjs

### DIFF
--- a/lib/self-service/self-service-manager.js
+++ b/lib/self-service/self-service-manager.js
@@ -15,6 +15,7 @@ const log4js = require("log4js");
 const got = require('got');
 const Q = require("q");
 const _ = require("underscore");
+const { parseJSON, jsonToURLencodedForm } = require('../utils/common-util');
 
 const logger = log4js.getLogger("self-service-manager");
 const VCAP_SERVICES = "VCAP_SERVICES";
@@ -266,30 +267,32 @@ let _handleRequest = function (iamToken, method, url, body, queryObject, action,
 			}
 			
 			const response = await got(url, reqParameters);
-			const responseBody = response.body;
+			const responseBody = parseJSON(response?.body);
 			
 			if (response.statusCode >= 200 && response.statusCode < 300) {
 				logger.debug("request " + action + " success");
 				logger.debug("response body: " + JSON.stringify(responseBody));
 				deferred.resolve(responseBody);
-			} else {
-				throw(responseBody?.error_description);
 			}
-		} catch (err) {
-			let error = new Error();
-			if (typeof err?.body === "object") {
-				let responseBody = err.body;
+			else {
+				let error = new Error();
 				logger.debug("request " + action + " failure");
-				error.statusCode = err && err.statusCode;
+				error.statusCode = response && response.statusCode;
 				if (responseBody && responseBody.scimType) {
 					error.code = responseBody.scimType;
 				}
-				error.message = responseBody && (responseBody.detail || responseBody.message || responseBody.error) || ((!_.isString(responseBody)) ? JSON.stringify(responseBody) : responseBody);
-			} else {
-				logger.error(err);
-				error.code = GENERAL_ERROR;
-				error.message = "Failed to " + action;
+				if (responseBody.error) {
+					error.message =	responseBody.error
+				} else {
+					error.message = responseBody && (responseBody.detail || responseBody.message || responseBody.error) || ((!_.isString(responseBody)) ? JSON.stringify(responseBody) : responseBody);
+				}
+				deferred.reject(error);
 			}
+		} catch (err) {
+			let error = new Error();
+			logger.error(err);
+			error.code = GENERAL_ERROR;
+			error.message = "Failed to " + action;
 			deferred.reject(error);
 		}
 	})();
@@ -313,49 +316,37 @@ let _getIAMToken = function (iamToken, iamApiKey, iamTokenUrl) {
 
 				const reqParameters = {
 					headers: {
+						"Accept": "application/json",
 						"Content-Type": "application/x-www-form-urlencoded"
 					},
+					method: "POST",
 					body: jsonToURLencodedForm(formData),
 					responseType: 'json'
 				};
 
-				const response = await got.post(iamTokenUrl, reqParameters);
-				const body = response.body && JSON.parse(response.body);
+				const response = await got(iamTokenUrl, reqParameters);
+				const body = parseJSON(response?.body);
 				
 				if (response.statusCode === 200) {
 					var IAMAccessToken = body["access_token"];
 					logger.debug("Obtained IAM token: " + IAMAccessToken);
 					resolve(IAMAccessToken);
-				} else {
-					let error = new Error();
-					error.statusCode = response.statusCode;
-					error.body =  body;
-					throw (error);
+				}
+				else if (response.error) {
+					throw(response.error);
+				}
+				else {
+					logger.error("Obtained IAM token failure");
+					logger.error("Got status code: " + response.statusCode);
+					logger.error(body);
+					reject(body);
 				}
 			} catch (err) {
-				logger.error("Obtained IAM token failure: " + err.body);
-				logger.error("Got status code: " + err.statusCode);
-				reject(err.body);
+				logger.error("Obtained IAM token failure: " + err.message);
+				reject(err.message);
 			}
 		})();
 	});
 };
-
-function jsonToURLencodedForm(srcjson){
-    if(typeof srcjson !== "object")
-		if(typeof console !== "undefined"){
-		console.log("\"srcjson\" is not a JSON object");
-		return null;
-	}
-
-    let u = encodeURIComponent;
-    let urljson = "";
-    let keys = Object.keys(srcjson);
-    for(var i=0; i <keys.length; i++){
-        urljson += u(keys[i]) + "=" + u(srcjson[keys[i]]);
-        if(i < (keys.length-1))urljson+="&";
-    }
-    return urljson;
-}
 
 module.exports = SelfServiceManager;

--- a/lib/self-service/self-service-manager.js
+++ b/lib/self-service/self-service-manager.js
@@ -12,7 +12,7 @@
  */
 "use strict";
 const log4js = require("log4js");
-let request = require("request");
+const got = require('got');
 const Q = require("q");
 const _ = require("underscore");
 
@@ -248,40 +248,51 @@ SelfServiceManager.prototype.updateUserDetails = function (uuid, userData, iamTo
 };
 
 let _handleRequest = function (iamToken, method, url, body, queryObject, action, deferred) {
-	let reqOptions = {
-		url: url,
-		method: method,
-		qs: queryObject,
-		json: true,
-		headers: {
-			"Authorization": "Bearer " + iamToken
-		}
-	};
-	if (method !== GET) {
-		reqOptions.json = body;
-	}
-	request(reqOptions, function (err, response, responseBody) {
-		if (!err && response.statusCode >= 200 && response.statusCode < 300) {
-			logger.debug("request " + action + " success");
-			logger.debug("response body: " + JSON.stringify(responseBody));
-			deferred.resolve(responseBody);
-		} else {
-			let error = new Error();
-			if (err) {
-				logger.error(err);
-				error.code = GENERAL_ERROR;
-				error.message = "Failed to " + action;
+	(async () => {
+		try {
+			let reqParameters = {
+				headers: {
+					"Authorization": "Bearer " + iamToken
+				},
+				method: method,
+				json: true,
+				searchParams: queryObject,
+				responseType: 'json'
+			};
+
+			if (method !== GET) {
+				reqParameters.body = body;
+				reqParameters.headers["Content-type"] = 'application/json';
+			}
+			
+			const response = await got(url, reqParameters);
+			const responseBody = response.body;
+			
+			if (response.statusCode >= 200 && response.statusCode < 300) {
+				logger.debug("request " + action + " success");
+				logger.debug("response body: " + JSON.stringify(responseBody));
+				deferred.resolve(responseBody);
 			} else {
+				throw(responseBody?.error_description);
+			}
+		} catch (err) {
+			let error = new Error();
+			if (typeof err?.body === "object") {
+				let responseBody = err.body;
 				logger.debug("request " + action + " failure");
-				error.statusCode = response && response.statusCode;
+				error.statusCode = err && err.statusCode;
 				if (responseBody && responseBody.scimType) {
 					error.code = responseBody.scimType;
 				}
 				error.message = responseBody && (responseBody.detail || responseBody.message || responseBody.error) || ((!_.isString(responseBody)) ? JSON.stringify(responseBody) : responseBody);
+			} else {
+				logger.error(err);
+				error.code = GENERAL_ERROR;
+				error.message = "Failed to " + action;
 			}
 			deferred.reject(error);
 		}
-	});
+	})();
 };
 
 let _getIAMToken = function (iamToken, iamApiKey, iamTokenUrl) {
@@ -291,37 +302,60 @@ let _getIAMToken = function (iamToken, iamApiKey, iamTokenUrl) {
 	if (!iamApiKey) {
 		return Promise.reject("You must pass 'iamToken' to self-service-manager APIs or specify 'iamApiKey' in selfServiceManager init options.");
 	}
-	var reqOptions = {
-		url: iamTokenUrl,
-		method: "POST",
-		headers: {
-			"Content-Type": "application/x-www-form-urlencoded",
-			"Accept": "application/json"
-		},
-		form: {
-			"grant_type": "urn:ibm:params:oauth:grant-type:apikey",
-			"apikey": iamApiKey
-		}
-	};
+
 	return new Promise(function (resolve, reject) {
-		request(reqOptions, function (error, response, body) {
-			if (error) {
-				logger.error("Obtained IAM token failure: " + error.message);
-				reject(error.message);
-			} else {
+		(async () => {
+			try {
+				let formData = {
+					"grant_type": "urn:ibm:params:oauth:grant-type:apikey",
+					"apikey": iamApiKey
+				}
+
+				const reqParameters = {
+					headers: {
+						"Content-Type": "application/x-www-form-urlencoded"
+					},
+					body: jsonToURLencodedForm(formData),
+					responseType: 'json'
+				};
+
+				const response = await got.post(iamTokenUrl, reqParameters);
+				const body = response.body && JSON.parse(response.body);
+				
 				if (response.statusCode === 200) {
-					var IAMAccessToken = JSON.parse(body)["access_token"];
+					var IAMAccessToken = body["access_token"];
 					logger.debug("Obtained IAM token: " + IAMAccessToken);
 					resolve(IAMAccessToken);
 				} else {
-					logger.error("Obtained IAM token failure");
-					logger.error("Got status code: " + response.statusCode);
-					logger.error(body);
-					reject(body);
+					let error = new Error();
+					error.statusCode = response.statusCode;
+					error.body =  body;
+					throw (error);
 				}
+			} catch (err) {
+				logger.error("Obtained IAM token failure: " + err.body);
+				logger.error("Got status code: " + err.statusCode);
+				reject(err.body);
 			}
-		});
+		})();
 	});
 };
+
+function jsonToURLencodedForm(srcjson){
+    if(typeof srcjson !== "object")
+		if(typeof console !== "undefined"){
+		console.log("\"srcjson\" is not a JSON object");
+		return null;
+	}
+
+    let u = encodeURIComponent;
+    let urljson = "";
+    let keys = Object.keys(srcjson);
+    for(var i=0; i <keys.length; i++){
+        urljson += u(keys[i]) + "=" + u(srcjson[keys[i]]);
+        if(i < (keys.length-1))urljson+="&";
+    }
+    return urljson;
+}
 
 module.exports = SelfServiceManager;

--- a/lib/self-service/self-service-manager.js
+++ b/lib/self-service/self-service-manager.js
@@ -267,7 +267,7 @@ let _handleRequest = function (iamToken, method, url, body, queryObject, action,
 			}
 			
 			const response = await got(url, reqParameters);
-			const responseBody = parseJSON(response?.body);
+			const responseBody = response.body && parseJSON(response.body);
 			
 			if (response.statusCode >= 200 && response.statusCode < 300) {
 				logger.debug("request " + action + " success");
@@ -282,9 +282,23 @@ let _handleRequest = function (iamToken, method, url, body, queryObject, action,
 					error.code = responseBody.scimType;
 				}
 				if (responseBody.error) {
-					error.message =	responseBody.error
+					error.message =	responseBody.error;
 				} else {
-					error.message = responseBody && (responseBody.detail || responseBody.message || responseBody.error) || ((!_.isString(responseBody)) ? JSON.stringify(responseBody) : responseBody);
+					// Get the error message
+					var errorMessage = responseBody.detail || responseBody.message || responseBody.error;
+					if (responseBody) {
+						if (errorMessage) {
+							error.message =	errorMessage;
+						}
+
+						else if (!_.isString(responseBody)){
+							error.message =	JSON.stringify(responseBody);
+						}
+
+						else {
+							error.message =	responseBody;
+						}
+					}
 				}
 				deferred.reject(error);
 			}
@@ -309,7 +323,7 @@ let _getIAMToken = function (iamToken, iamApiKey, iamTokenUrl) {
 	return new Promise(function (resolve, reject) {
 		(async () => {
 			try {
-				let formData = {
+				const formData = {
 					"grant_type": "urn:ibm:params:oauth:grant-type:apikey",
 					"apikey": iamApiKey
 				}
@@ -325,7 +339,7 @@ let _getIAMToken = function (iamToken, iamApiKey, iamTokenUrl) {
 				};
 
 				const response = await got(iamTokenUrl, reqParameters);
-				const body = parseJSON(response?.body);
+				const body = response.body && parseJSON(response.body);
 				
 				if (response.statusCode === 200) {
 					var IAMAccessToken = body["access_token"];

--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -12,7 +12,8 @@
  */
 "use strict";
 const log4js = require("log4js");
-const request = require("request");
+const got = require('got');
+const FormData = require('form-data');
 const Q = require("q");
 const acceptLanguage = require('accept-language');
 const constants = require('../utils/constants');
@@ -200,15 +201,18 @@ function handleChangeDetails(req, options, strategy) {
 	}
 
 	var generateCodeUrl = strategy.serviceConfig.getOAuthServerUrl() + GENERATE_CODE_PATH;
-	request({
-		'url': generateCodeUrl,
-		'auth': {
-			'bearer': appIdAuthContext.accessToken + ' ' + appIdAuthContext.identityToken
-		}
-	}, function (error, response, body) {
-		if (!error) {
+
+	(async () => {
+		try {
+			const reqParameters = {
+				headers: {
+					"Authorization" : `Bearer ${appIdAuthContext.accessToken} ${appIdAuthContext.identityToken}`
+				}
+			}
+			const response = await got(generateCodeUrl, reqParameters);
+			
 			if (response.statusCode === 200) {
-				var code = body;
+				var code = response.body;
 				var changeDetailsUrl = generateChangeDetailsUrl(code, req, strategy);
 				logger.debug("handleChangeDetails :: redirecting to", changeDetailsUrl);
 				req.session[WebAppStrategy.CLOUD_DIRECTORY_UPDATE_REQ] = true;
@@ -217,11 +221,11 @@ function handleChangeDetails(req, options, strategy) {
 				logger.error('generate code response not 200, got status:' + response.statusCode);
 				strategy.fail(new Error('generate code: response status code:' + response.statusCode));
 			}
-		} else {
-			logger.error('generate code request error: ' + error.message);
-			strategy.fail(error);
+		} catch (err) {
+			logger.error('generate code request error: ' + err.message);
+			strategy.fail(err);
 		}
-	});
+	})();
 }
 
 function handleRopFlow(options, req, strategy) {
@@ -427,6 +431,11 @@ function generateAuthorizationUrl(options, req, strategy) {
 	return addLocaleToQuery(req, authUrl, strategy);
 }
 
+const getFormData = object => Object.keys(object).reduce((formData, key) => {
+    formData.append(key, object[key]);
+    return formData;
+}, new FormData());
+
 function retrieveTokens(formData, strategy) {
 	logger.debug("retrieveTokens");
 	return new Promise((resolve, reject) => {
@@ -435,75 +444,80 @@ function retrieveTokens(formData, strategy) {
 		const secret = serviceConfig.getSecret();
 		const tokenEndpoint = serviceConfig.getOAuthServerUrl() + TOKEN_PATH;
 		const publicKeysEndpoint = serviceConfig.getOAuthServerUrl();
-		request({
-			method: "POST",
-			url: tokenEndpoint,
-			auth: {
-				username: clientId,
-				password: secret
-			},
-			formData: formData
-		}, function (err, response, strBody) {
-			if (err) {
-				logger.error("Failed to obtain tokens ::", err);
-				reject(err);
-			} else if (response.statusCode !== 200) {
-				try {
-					logger.error("Failed to obtain tokens ::", response && response.statusCode, strBody);
-					let body = strBody && JSON.parse(strBody);
-					let loginErrMsg = "Failed to obtain tokens";
 
-					if (body && (body.error === INVALID_GRANT || body["error_code"] === FORBIDDEN)) {
-						loginErrMsg = body.error_description;
-					}
-					let loginError = new Error(loginErrMsg);
-					loginError.statusCode = response && response.statusCode;
-					loginError.code = (body.error || body["error_code"]).toLowerCase();
-					return reject(loginError);
-				} catch (e) {
-					logger.error(e);
-					return reject(new Error("Failed to obtain tokens"));
-				}
-			} else {
-				let body = strBody && JSON.parse(strBody);
-				const accessTokenString = body["access_token"];
-				const identityTokenString = body["id_token"];
-				const refreshToken = body["refresh_token"];
 
-				// Parse access_token
-				var appIdAuthorizationContext = {
-					refreshToken: refreshToken
-				};
-
-				Promise.all([
-					TokenUtil.decodeAndValidate(accessTokenString, publicKeysEndpoint),
-					TokenUtil.decodeAndValidate(identityTokenString, publicKeysEndpoint)]).then(function (tokens) {
-					if (tokens.length < 2 || !tokens[0] || !tokens[1]) {
-						throw new Error("Invalid access/id token");
-					}
-					const [accessToken, idToken] = tokens;
-
-					return TokenUtil.validateIssAndAud(accessToken, serviceConfig)
-						.then(() => TokenUtil.validateIssAndAud(idToken, serviceConfig))
-						.then(() => {
-							appIdAuthorizationContext.accessToken = accessTokenString;
-							appIdAuthorizationContext.accessTokenPayload = tokens[0];
-							appIdAuthorizationContext.identityToken = identityTokenString;
-							appIdAuthorizationContext.identityTokenPayload = tokens[1];
-							logger.debug("authentication success");
-							resolve(appIdAuthorizationContext);
-						})
-						.catch(err => {
-							logger.error(err);
-							throw new Error("token validation failed");
-						});
-				}).catch(function (error) {
-					logger.debug("Authentication failed : " + error.message);
-					reject(new Error("Authentication failed : " + error.message));
-				});
+        (async () => {
+         try {
+			const reqParameters = {
+				headers: {
+					"Authorization": "Basic " + Buffer.from(`${clientId}:${secret}`).toString("base64")
+				},
+				body: getFormData(formData),
+				responseType: 'json',
+				throwHttpErrors: false
 			}
-		});
+			const response = await got.post(tokenEndpoint, reqParameters);
+			const body = response.body && JSON.parse(response.body);
+             
+             if (response.statusCode !== 200) {
+              try {
+                  logger.error("Failed to obtain tokens ::", response && response.statusCode, body);
+                  let loginErrMsg = "Failed to obtain tokens";
 
+                  if (body && (body.error === INVALID_GRANT || body["error_code"] === FORBIDDEN)) {
+                      loginErrMsg = body.error_description;
+                  }
+                  let loginError = new Error(loginErrMsg);
+                  loginError.statusCode = response && response.statusCode;
+                  loginError.code = (body.error || body["error_code"]).toLowerCase();
+                  return reject(loginError);
+              } catch (e) {   
+                  logger.error(e);
+                  return reject(new Error("Failed to obtain tokens"));
+              }
+             }
+             else {
+              const accessTokenString = body["access_token"];
+              const identityTokenString = body["id_token"];
+              const refreshToken = body["refresh_token"];
+
+              // Parse access_token
+              var appIdAuthorizationContext = {
+                  refreshToken: refreshToken
+              };
+
+              Promise.all([
+                  TokenUtil.decodeAndValidate(accessTokenString, publicKeysEndpoint),
+                  TokenUtil.decodeAndValidate(identityTokenString, publicKeysEndpoint)]).then(function (tokens) {
+                  if (tokens.length < 2 || !tokens[0] || !tokens[1]) {
+                      throw new Error("Invalid access/id token");
+                  }
+                  const [accessToken, idToken] = tokens;
+
+                  return TokenUtil.validateIssAndAud(accessToken, serviceConfig)
+                      .then(() => TokenUtil.validateIssAndAud(idToken, serviceConfig))
+                      .then(() => {
+                          appIdAuthorizationContext.accessToken = accessTokenString;
+                          appIdAuthorizationContext.accessTokenPayload = tokens[0];
+                          appIdAuthorizationContext.identityToken = identityTokenString;
+                          appIdAuthorizationContext.identityTokenPayload = tokens[1];
+                          logger.debug("authentication success");
+                          resolve(appIdAuthorizationContext);
+                      })
+                      .catch(err => {
+                          logger.error(err);
+                          throw new Error("token validation failed");
+                      });
+              }).catch(function (error) {
+                  logger.debug("Authentication failed : " + error.message);
+                  reject(new Error("Authentication failed : " + error.message));
+              });
+             }
+         } catch (err) {
+             logger.error("Failed to obtain tokens ::", err);
+             reject(err);
+         }
+        })();
 	});
 }
 
@@ -516,25 +530,27 @@ function logAction(req, url, activity) {
 		return;
 	}
 
-	let requestData = {
-		'eventName': activity,
-		'id_token': appIdAuthContext.identityToken
-	};
+	(async () => {
+		let requestData = {
+			eventName: activity,
+			id_token: appIdAuthContext.identityToken
+		};
 
-	request({
-		'method': "POST",
-		'url': loggingEndpoint,
-		'json': requestData,
-		'auth': {
-			'bearer': appIdAuthContext.accessToken
-		}
-	}, function (error, response) {
-		if (error) {
-			logger.debug('logging request error: ' + error);
-		} else {
+		try {
+			const reqParameters = {
+				headers: {
+					"Authorization" : `Bearer ${appIdAuthContext.accessToken}`,
+					"content-type": "application/json"
+				},
+				body: JSON.stringify(requestData),
+				responseType: 'json'
+			}
+			const response = await got.post(loggingEndpoint, reqParameters);
 			logger.debug('logging request ok: ' + response.statusCode);
+		} catch (err) {
+			logger.debug('logging request error: ' + err);
 		}
-	});
+	})();
 }
 
 /**

--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -533,7 +533,7 @@ function logAction(req, url, activity) {
 	}
 
 	(async () => {
-		let requestData = {
+		const requestData = {
 			eventName: activity,
 			id_token: appIdAuthContext.identityToken
 		};

--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -13,13 +13,13 @@
 "use strict";
 const log4js = require("log4js");
 const got = require('got');
-const FormData = require('form-data');
 const Q = require("q");
 const acceptLanguage = require('accept-language');
 const constants = require('../utils/constants');
 const TokenUtil = require("../utils/token-util");
 const ServiceUtil = require('../utils/service-util');
 const appIdSupportedLanguagesArray = require("../data/languagesCodesArray");
+const { parseJSON } = require('../utils/common-util');
 
 acceptLanguage.languages(appIdSupportedLanguagesArray);
 
@@ -431,11 +431,6 @@ function generateAuthorizationUrl(options, req, strategy) {
 	return addLocaleToQuery(req, authUrl, strategy);
 }
 
-const getFormData = object => Object.keys(object).reduce((formData, key) => {
-    formData.append(key, object[key]);
-    return formData;
-}, new FormData());
-
 function retrieveTokens(formData, strategy) {
 	logger.debug("retrieveTokens");
 	return new Promise((resolve, reject) => {
@@ -450,16 +445,22 @@ function retrieveTokens(formData, strategy) {
          try {
 			const reqParameters = {
 				headers: {
-					"Authorization": "Basic " + Buffer.from(`${clientId}:${secret}`).toString("base64")
+					"Authorization": "Basic " + Buffer.from(`${clientId}:${secret}`).toString("base64"),
+					"Content-Type": "application/json"
 				},
-				body: getFormData(formData),
+				method: "POST",
+				body: JSON.stringify(formData),
 				responseType: 'json',
 				throwHttpErrors: false
 			}
-			const response = await got.post(tokenEndpoint, reqParameters);
-			const body = response.body && JSON.parse(response.body);
-             
-             if (response.statusCode !== 200) {
+			const response = await got(tokenEndpoint, reqParameters);
+			const body = parseJSON(response.body);
+			
+             if(response.error) {
+				throw(response.error);
+			 }
+
+             else if (response.statusCode !== 200) {
               try {
                   logger.error("Failed to obtain tokens ::", response && response.statusCode, body);
                   let loginErrMsg = "Failed to obtain tokens";
@@ -469,13 +470,14 @@ function retrieveTokens(formData, strategy) {
                   }
                   let loginError = new Error(loginErrMsg);
                   loginError.statusCode = response && response.statusCode;
-                  loginError.code = (body.error || body["error_code"]).toLowerCase();
+                  loginError.code = (body.error || body.message || body["error_code"]).toLowerCase();
                   return reject(loginError);
               } catch (e) {   
                   logger.error(e);
                   return reject(new Error("Failed to obtain tokens"));
               }
              }
+
              else {
               const accessTokenString = body["access_token"];
               const identityTokenString = body["id_token"];
@@ -542,10 +544,11 @@ function logAction(req, url, activity) {
 					"Authorization" : `Bearer ${appIdAuthContext.accessToken}`,
 					"content-type": "application/json"
 				},
+				method: "POST",
 				body: JSON.stringify(requestData),
 				responseType: 'json'
 			}
-			const response = await got.post(loggingEndpoint, reqParameters);
+			const response = await got(loggingEndpoint, reqParameters);
 			logger.debug('logging request ok: ' + response.statusCode);
 		} catch (err) {
 			logger.debug('logging request error: ' + err);

--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -431,18 +431,15 @@ function generateAuthorizationUrl(options, req, strategy) {
 	return addLocaleToQuery(req, authUrl, strategy);
 }
 
-function retrieveTokens(formData, strategy) {
+async function retrieveTokens(formData, strategy) {
 	logger.debug("retrieveTokens");
-	return new Promise((resolve, reject) => {
 		const serviceConfig = strategy.serviceConfig;
 		const clientId = serviceConfig.getClientId();
 		const secret = serviceConfig.getSecret();
 		const tokenEndpoint = serviceConfig.getOAuthServerUrl() + TOKEN_PATH;
 		const publicKeysEndpoint = serviceConfig.getOAuthServerUrl();
 
-
-        (async () => {
-         try {
+		try {
 			const reqParameters = {
 				headers: {
 					"Authorization": "Basic " + Buffer.from(`${clientId}:${secret}`).toString("base64"),
@@ -455,72 +452,66 @@ function retrieveTokens(formData, strategy) {
 			}
 			const response = await got(tokenEndpoint, reqParameters);
 			const body = parseJSON(response.body);
-			
-             if(response.error) {
-				throw(response.error);
-			 }
 
-             else if (response.statusCode !== 200) {
-              try {
-                  logger.error("Failed to obtain tokens ::", response && response.statusCode, body);
-                  let loginErrMsg = "Failed to obtain tokens";
+				if (response.statusCode !== 200) {
+					try {
+						logger.error("Failed to obtain tokens ::", response && response.statusCode, body);
+						let loginErrMsg = "Failed to obtain tokens";
 
-                  if (body && (body.error === INVALID_GRANT || body["error_code"] === FORBIDDEN)) {
-                      loginErrMsg = body.error_description;
-                  }
-                  let loginError = new Error(loginErrMsg);
-                  loginError.statusCode = response && response.statusCode;
-                  loginError.code = (body.error || body.message || body["error_code"]).toLowerCase();
-                  return reject(loginError);
-              } catch (e) {   
-                  logger.error(e);
-                  return reject(new Error("Failed to obtain tokens"));
-              }
-             }
+						if (body && (body.error === INVALID_GRANT || body["error_code"] === FORBIDDEN)) {
+							loginErrMsg = body.error_description;
+						}
+						let loginError = new Error(loginErrMsg);
+						loginError.statusCode = response && response.statusCode;
+						loginError.code = (body.error || body.message || body["error_code"]).toLowerCase();
+						throw(loginError);
+					} catch (e) {   
+						logger.error(e);
+						throw(new Error("Failed to obtain tokens"));
+					}
+				}
 
-             else {
-              const accessTokenString = body["access_token"];
-              const identityTokenString = body["id_token"];
-              const refreshToken = body["refresh_token"];
+				else {
+				const accessTokenString = body["access_token"];
+				const identityTokenString = body["id_token"];
+				const refreshToken = body["refresh_token"];
 
-              // Parse access_token
-              var appIdAuthorizationContext = {
-                  refreshToken: refreshToken
-              };
+				// Parse access_token
+				var appIdAuthorizationContext = {
+					refreshToken: refreshToken
+				};
 
-              Promise.all([
-                  TokenUtil.decodeAndValidate(accessTokenString, publicKeysEndpoint),
-                  TokenUtil.decodeAndValidate(identityTokenString, publicKeysEndpoint)]).then(function (tokens) {
-                  if (tokens.length < 2 || !tokens[0] || !tokens[1]) {
-                      throw new Error("Invalid access/id token");
-                  }
-                  const [accessToken, idToken] = tokens;
+				return Promise.all([
+					TokenUtil.decodeAndValidate(accessTokenString, publicKeysEndpoint),
+					TokenUtil.decodeAndValidate(identityTokenString, publicKeysEndpoint)]).then(function (tokens) {
+					if (tokens.length < 2 || !tokens[0] || !tokens[1]) {
+						throw new Error("Invalid access/id token");
+					}
+					const [accessToken, idToken] = tokens;
 
-                  return TokenUtil.validateIssAndAud(accessToken, serviceConfig)
-                      .then(() => TokenUtil.validateIssAndAud(idToken, serviceConfig))
-                      .then(() => {
-                          appIdAuthorizationContext.accessToken = accessTokenString;
-                          appIdAuthorizationContext.accessTokenPayload = tokens[0];
-                          appIdAuthorizationContext.identityToken = identityTokenString;
-                          appIdAuthorizationContext.identityTokenPayload = tokens[1];
-                          logger.debug("authentication success");
-                          resolve(appIdAuthorizationContext);
-                      })
-                      .catch(err => {
-                          logger.error(err);
-                          throw new Error("token validation failed");
-                      });
-              }).catch(function (error) {
-                  logger.debug("Authentication failed : " + error.message);
-                  reject(new Error("Authentication failed : " + error.message));
-              });
-             }
-         } catch (err) {
-             logger.error("Failed to obtain tokens ::", err);
-             reject(err);
-         }
-        })();
-	});
+					return TokenUtil.validateIssAndAud(accessToken, serviceConfig)
+						.then(() => TokenUtil.validateIssAndAud(idToken, serviceConfig))
+						.then(() => {
+							appIdAuthorizationContext.accessToken = accessTokenString;
+							appIdAuthorizationContext.accessTokenPayload = tokens[0];
+							appIdAuthorizationContext.identityToken = identityTokenString;
+							appIdAuthorizationContext.identityTokenPayload = tokens[1];
+							logger.debug("authentication success");
+							return(appIdAuthorizationContext);
+						})
+						.catch(err => {
+							logger.error(err);
+							throw new Error("token validation failed");
+						});
+				}).catch(function (error) {
+					logger.debug("Authentication failed : " + error.message);
+					throw new Error("Authentication failed : " + error.message);
+				});
+			}
+		} catch (err) {
+			logger.error("Failed to obtain tokens ::", err);
+			throw(err);
+		}
 }
 
 function logAction(req, url, activity) {

--- a/lib/token-manager/token-manager.js
+++ b/lib/token-manager/token-manager.js
@@ -14,11 +14,11 @@
 const log4js = require("log4js");
 const logger = log4js.getLogger("appid-token-manager");
 const got = require('got');
-const FormData = require('form-data');
 
 const constants = require('../utils/constants');
 const TokenUtil = require("../utils/token-util");
 const ServiceUtil = require('../utils/service-util');
+const { parseJSON } = require('../utils/common-util');
 
 
 function TokenManager(options) {
@@ -92,21 +92,23 @@ function getTokens(tokenEndpoint, clientId, secret, grant_type, scope, assertion
 
 		(async () => {
 			try {
-				let formD = new FormData();
-				formD.append('grant_type', grant_type);
-				formD.append('scope', scope);
-				formD.append('assertion', assertion);
+				const form = {
+					grant_type,
+					scope,
+					assertion
+				}
 
 				const reqParameters = {
 					headers: {
 						"Authorization": "Basic " + Buffer.from(`${clientId}:${secret}`).toString("base64")
 					},
-					body: formD,
+					method: "POST",
+					body: JSON.stringify(form),
                  	responseType: 'json',
 					throwHttpErrors: false
 				}
-				const response = await got.post(tokenEndpoint, reqParameters);
-				const body = response.body && JSON.parse(response.body);
+				const response = await got(tokenEndpoint, reqParameters);
+				const body = parseJSON(response.body);
 				
 				if (response.statusCode === 200) {
 					resolve(body);

--- a/lib/token-manager/token-manager.js
+++ b/lib/token-manager/token-manager.js
@@ -114,13 +114,15 @@ function getTokens(tokenEndpoint, clientId, secret, grant_type, scope, assertion
 					resolve(body);
 				} 
 				else if (response.statusCode === 401 || response.statusCode === 403) {
-					logger.error('Unauthorized. Error: ', body.error_description);
+					let errorMessage = body.error_description || '';
+					logger.error('Unauthorized. Error: ', errorMessage);
 					reject(new Error('Unauthorized'));
 				} else if (response.statusCode === 404) {
 					logger.error('Not found');
 					reject(new Error("Not found"));
 				} else if (response.statusCode === 400) {
-					logger.error('Failed to obtain tokens. Error: ', body.error_description);
+					let errorMessage = body.error_description || '';
+					logger.error('Failed to obtain tokens. Error: ', errorMessage);
 					reject(new Error('Failed to obtain tokens'));
 				} else {
 					logger.error(body);

--- a/lib/token-manager/token-manager.js
+++ b/lib/token-manager/token-manager.js
@@ -13,7 +13,8 @@
 
 const log4js = require("log4js");
 const logger = log4js.getLogger("appid-token-manager");
-const request = require("request");
+const got = require('got');
+const FormData = require('form-data');
 
 const constants = require('../utils/constants');
 const TokenUtil = require("../utils/token-util");
@@ -88,40 +89,46 @@ TokenManager.prototype.getApplicationIdentityToken = function () {
 
 function getTokens(tokenEndpoint, clientId, secret, grant_type, scope, assertion) {
 	return new Promise((resolve, reject) => {
-		request({
-			method: 'POST',
-			url: tokenEndpoint,
-			auth: {
-				username: clientId,
-				password: secret
-			},
-			form: {
-				grant_type,
-				scope,
-				assertion
-			}
-		}, (error, response, body) => {
-			if (error) {
-				logger.error('Failed to obtain tokens. Error: ', error);
-				reject(error);
-			} else if (response.statusCode === 200) {
-				resolve(JSON.parse(body));
-			} else {
-				if (response.statusCode === 401 || response.statusCode === 403) {
-					logger.error('Unauthorized. Error: ', JSON.parse(body).error_description);
+
+		(async () => {
+			try {
+				let formD = new FormData();
+				formD.append('grant_type', grant_type);
+				formD.append('scope', scope);
+				formD.append('assertion', assertion);
+
+				const reqParameters = {
+					headers: {
+						"Authorization": "Basic " + Buffer.from(`${clientId}:${secret}`).toString("base64")
+					},
+					body: formD,
+                 	responseType: 'json',
+					throwHttpErrors: false
+				}
+				const response = await got.post(tokenEndpoint, reqParameters);
+				const body = response.body && JSON.parse(response.body);
+				
+				if (response.statusCode === 200) {
+					resolve(body);
+				} 
+				else if (response.statusCode === 401 || response.statusCode === 403) {
+					logger.error('Unauthorized. Error: ', body.error_description);
 					reject(new Error('Unauthorized'));
 				} else if (response.statusCode === 404) {
 					logger.error('Not found');
 					reject(new Error("Not found"));
 				} else if (response.statusCode === 400) {
-					logger.error('Failed to obtain tokens. Error: ', JSON.parse(body).error_description);
+					logger.error('Failed to obtain tokens. Error: ', body.error_description);
 					reject(new Error('Failed to obtain tokens'));
 				} else {
-					logger.error(JSON.parse(body));
+					logger.error(body);
 					reject(new Error("Unexpected error"));
 				}
+			} catch (err) {
+				logger.error('Failed to obtain tokens. Error: ', err);
+				reject(err);
 			}
-		});
+		})();
 	});
 }
 

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -179,7 +179,7 @@ UserProfileManager.prototype.getUserInfo = function (accessToken, identityToken)
 function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 	(async () => {
 		try {
-			let reqParameters = {
+			const reqParameters = {
 				headers: {
 					"Authorization": "Bearer " + accessToken
 				},

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -28,6 +28,7 @@ const ATTRIBUTES_ENDPOINT = "/api/v1/attributes";
 const USERINFO_ENDPOINT = "/userinfo";
 
 const serviceUtils = require('../utils/service-util');
+const { parseJSON } = require('../utils/common-util');
 
 function UserProfileManager() {
 }
@@ -188,8 +189,11 @@ function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 			};
 			
 			const response = await got(url, reqParameters);
-			const body = response.body && JSON.parse(response.body);
+			const body = parseJSON(response.body);
 			
+			// Add URL to the result body.
+			body.url = url;
+
 			if (response.statusCode >= 200 && response.statusCode < 300) {
 				return deferred.resolve(body ? body : null);
 			} else {

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -200,9 +200,10 @@ function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 			} else if (response.statusCode === 404) {
 				return deferred.reject(new Error("Not found"));
 			} else if (response.statusCode >= 200 && response.statusCode < 300) {
-				return deferred.resolve(body ? JSON.parse(body) : null);
+				return deferred.resolve(body ? body : null);
 			} else {
-				logger.error(response, response.headers);
+				let errorMessage = response.error ? response.error: response;
+				logger.error(errorMessage, response.headers);
 				return deferred.reject(new Error("Unexpected error"));
 			}
 		} catch (err) {

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -189,7 +189,7 @@ function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 			};
 			
 			const response = await got(url, reqParameters);
-			const body = parseJSON(response.body);
+			let body = parseJSON(response.body);
 			
 			// Add URL to the result body.
 			body.url = url;

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -12,7 +12,7 @@
  */
 
 const log4js = require("log4js");
-const request = require("request");
+const got = require('got');
 const Q = require("q");
 const _ = require("underscore");
 const UnauthorizedException = require("./unauthorized-exception");
@@ -176,29 +176,37 @@ UserProfileManager.prototype.getUserInfo = function (accessToken, identityToken)
 };
 
 function handleRequest(accessToken, reqBody, method, url, action, deferred) {
-
-	request({
-		url: url,
-		method: method,
-		body: reqBody,
-		headers: {
-			"Authorization": "Bearer " + accessToken
+	(async () => {
+		try {
+			let reqParameters = {
+				headers: {
+					"Authorization": "Bearer " + accessToken
+				},
+				method: method,
+				body: reqBody,
+				responseType: 'json'
+			};
+			
+			const response = await got(url, reqParameters);
+			const body = response.body && JSON.parse(response.body);
+			
+			if (response.statusCode >= 200 && response.statusCode < 300) {
+				return deferred.resolve(body ? body : null);
+			} else {
+				logger.error(err, response.headers);
+				return deferred.reject(new Error("Unexpected error"));
+			}
+		} catch (err) {
+			if (err.statusCode === 401 || err.statusCode === 403) {
+				return deferred.reject(new UnauthorizedException());
+			} else if (err.statusCode === 404) {
+				return deferred.reject(new Error("Not found"));
+			} else {
+				logger.error(err);
+				return deferred.reject(new Error("Failed to " + action));
+			}
 		}
-	}, function (err, response, body) {
-		if (err) {
-			logger.error(err);
-			return deferred.reject(new Error("Failed to " + action));
-		} else if (response.statusCode === 401 || response.statusCode === 403) {
-			return deferred.reject(new UnauthorizedException());
-		} else if (response.statusCode === 404) {
-			return deferred.reject(new Error("Not found"));
-		} else if (response.statusCode >= 200 && response.statusCode < 300) {
-			return deferred.resolve(body ? JSON.parse(body) : null);
-		} else {
-			logger.error(err, response.headers);
-			return deferred.reject(new Error("Unexpected error"));
-		}
-	});
+	})();
 }
 
 module.exports = new UserProfileManager();

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -185,7 +185,8 @@ function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 				},
 				method: method,
 				body: reqBody,
-				responseType: 'json'
+				responseType: 'json',
+				throwHttpErrors: false
 			};
 			
 			const response = await got(url, reqParameters);
@@ -194,21 +195,19 @@ function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 			// Add URL to the result body.
 			body.url = url;
 
-			if (response.statusCode >= 200 && response.statusCode < 300) {
-				return deferred.resolve(body ? body : null);
+			if (response.statusCode === 401 || response.statusCode === 403) {
+				return deferred.reject(new UnauthorizedException());
+			} else if (response.statusCode === 404) {
+				return deferred.reject(new Error("Not found"));
+			} else if (response.statusCode >= 200 && response.statusCode < 300) {
+				return deferred.resolve(body ? JSON.parse(body) : null);
 			} else {
-				logger.error(err, response.headers);
+				logger.error(response, response.headers);
 				return deferred.reject(new Error("Unexpected error"));
 			}
 		} catch (err) {
-			if (err.statusCode === 401 || err.statusCode === 403) {
-				return deferred.reject(new UnauthorizedException());
-			} else if (err.statusCode === 404) {
-				return deferred.reject(new Error("Not found"));
-			} else {
-				logger.error(err);
-				return deferred.reject(new Error("Failed to " + action));
-			}
+			logger.error(err);
+			return deferred.reject(new Error("Failed to " + action));
 		}
 	})();
 }

--- a/lib/user-profile-manager/user-profile-manager.js
+++ b/lib/user-profile-manager/user-profile-manager.js
@@ -176,7 +176,7 @@ UserProfileManager.prototype.getUserInfo = function (accessToken, identityToken)
 	return deferred.promise;
 };
 
-function handleRequest(accessToken, reqBody, method, url, action, deferred) {
+function handleRequest(accessToken, reqBody, method, reqUrl, action, deferred) {
 	(async () => {
 		try {
 			const reqParameters = {
@@ -189,11 +189,13 @@ function handleRequest(accessToken, reqBody, method, url, action, deferred) {
 				throwHttpErrors: false
 			};
 			
-			const response = await got(url, reqParameters);
+			const response = await got(reqUrl, reqParameters);
 			let body = parseJSON(response.body);
 			
 			// Add URL to the result body.
-			body.url = url;
+			if (body) {
+				body.url = reqUrl;
+			}
 
 			if (response.statusCode === 401 || response.statusCode === 403) {
 				return deferred.reject(new UnauthorizedException());

--- a/lib/utils/common-util.js
+++ b/lib/utils/common-util.js
@@ -1,0 +1,33 @@
+module.exports = (function () {
+    function jsonToURLencodedForm(srcjson){
+        if(typeof srcjson !== "object")
+            if(typeof console !== "undefined"){
+            console.log("\"srcjson\" is not a JSON object");
+            return null;
+        }
+    
+        let u = encodeURIComponent;
+        let urljson = "";
+        let keys = Object.keys(srcjson);
+        for(var i=0; i <keys.length; i++){
+            urljson += u(keys[i]) + "=" + u(srcjson[keys[i]]);
+            if(i < (keys.length-1))urljson+="&";
+        }
+        return urljson;
+    }
+
+    function parseJSON(jsonObj) {
+		try {
+			var json = JSON.parse(jsonObj);
+			return json;
+		} catch (e) {
+			return jsonObj;
+		}
+	}	
+    
+    return {
+        jsonToURLencodedForm,
+        parseJSON
+    };
+
+}());

--- a/lib/utils/common-util.js
+++ b/lib/utils/common-util.js
@@ -10,12 +10,12 @@ module.exports = (function () {
         return urljson;
     }
 
-    function parseJSON(jsonObj) {
+    function parseJSON(jsonStr) {
 		try {
-			var json = JSON.parse(jsonObj);
+			const json = JSON.parse(jsonStr);
 			return json;
 		} catch (e) {
-			return jsonObj;
+			return jsonStr;
 		}
 	}	
     

--- a/lib/utils/common-util.js
+++ b/lib/utils/common-util.js
@@ -1,11 +1,5 @@
 module.exports = (function () {
     function jsonToURLencodedForm(srcjson){
-        if(typeof srcjson !== "object")
-            if(typeof console !== "undefined"){
-            console.log("\"srcjson\" is not a JSON object");
-            return null;
-        }
-    
         let u = encodeURIComponent;
         let urljson = "";
         let keys = Object.keys(srcjson);

--- a/lib/utils/public-key-util.js
+++ b/lib/utils/public-key-util.js
@@ -15,7 +15,7 @@ const log4js = require("log4js");
 
 const logger = log4js.getLogger("appid-public-key-util");
 const Q = require("q");
-const request = require("request");
+const got = require('got');
 const pemFromModExp = require("rsa-pem-from-mod-exp");
 
 const TIMEOUT = 15 * 1000;
@@ -45,24 +45,36 @@ module.exports = (function () {
 	function _updatePublicKeys(publicKeysUrl) {
 		let deferred = Q.defer();
 		logger.debug("Getting public key from", publicKeysUrl);
-		request({
-			method: "GET",
-			url: publicKeysUrl,
-			json: true,
-			timeout: TIMEOUT,
-			headers: {"x-filter-type": "nodejs"}
-		}, function (error, response, body) {
-			
-			if (error || response.statusCode !== 200) {
+
+		(async () => {
+			try {
+				const reqParameters = {
+					headers: { "x-filter-type": "nodejs" },
+					responseType: 'json',
+					timeout: TIMEOUT,
+				}
+				const response = await got(publicKeysUrl, reqParameters);
+				const body = JSON.parse(response.body);
+
+				if (response.statusCode !== 200) {
+					HandleError();
+				}
+				else {
+					deferred.resolve(body.keys);
+				}
+			} catch (err) {
+				HandleError();
+			}
+
+			function HandleError() {
 				if (typeof publicKeysJson[publicKeysUrl] === 'undefined') {
 					deferred.reject("Failed to retrieve public keys.  All requests to protected endpoints will be rejected.");
 				} else {
 					deferred.reject("Failed to update public keys.");
 				}
-			} else {
-				deferred.resolve(body.keys);
 			}
-		});
+		})();
+
 		return deferred.promise;
 	}
 	

--- a/lib/utils/public-key-util.js
+++ b/lib/utils/public-key-util.js
@@ -54,7 +54,7 @@ module.exports = (function () {
 					timeout: TIMEOUT,
 				}
 				const response = await got(publicKeysUrl, reqParameters);
-				const body = JSON.parse(response.body);
+				const body = parseJSON(response.body);
 
 				if (response.statusCode !== 200) {
 					HandleError();
@@ -78,6 +78,15 @@ module.exports = (function () {
 		return deferred.promise;
 	}
 	
+	function parseJSON(jsonObj) {
+		try {
+			var json = JSON.parse(jsonObj);
+			return json;
+		} catch (e) {
+			return jsonObj;
+		}
+	}	  
+
 	function getPublicKeyPemByKid(tokenKid, serverUrl) {
 		let deferred = Q.defer();
 

--- a/lib/utils/public-key-util.js
+++ b/lib/utils/public-key-util.js
@@ -17,6 +17,7 @@ const logger = log4js.getLogger("appid-public-key-util");
 const Q = require("q");
 const got = require('got');
 const pemFromModExp = require("rsa-pem-from-mod-exp");
+const { parseJSON } = require('./common-util');
 
 const TIMEOUT = 15 * 1000;
 
@@ -77,15 +78,6 @@ module.exports = (function () {
 
 		return deferred.promise;
 	}
-	
-	function parseJSON(jsonObj) {
-		try {
-			var json = JSON.parse(jsonObj);
-			return json;
-		} catch (e) {
-			return jsonObj;
-		}
-	}	  
 
 	function getPublicKeyPemByKid(tokenKid, serverUrl) {
 		let deferred = Q.defer();

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -96,20 +96,17 @@ module.exports = (function () {
 				const reqParameters = {
 					responseType: 'json',
 					timeout: TIMEOUT,
+					throwHttpErrors: false
 				}
 				const response = await got(wellKnownEndpoint, reqParameters);
 				const body = parseJSON(response.body);
 
 				if (response.error || response.statusCode !== 200) {
+					let errMessage;
 					if(response.error){
-						HandleError(response.error);
+						errMessage = response.error;
 					}
-					else if(body.error_description){
-						HandleError(body.error_description);
-					}
-					else {
-						HandleError();
-					}
+					HandleError(errMessage);
 				}
 				else if (body.issuer) {
 					logger.debug("Got ISSUER from well known endpoint: " + body.issuer);

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -11,7 +11,7 @@
  limitations under the License.
  */
 
-const request = require("request");
+const got = require('got');
 const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 const Q = require("q");
@@ -90,26 +90,38 @@ module.exports = (function () {
 	
 	
 	return new Promise(function (resolve, reject) {
-	  request({
-		method: "GET",
-		url: wellKnownEndpoint,
-		json: true,
-		timeout: TIMEOUT
-	  }, function (error, response, body) {
-		if (error || response.statusCode !== 200) {
-		  const errmsg = "Failed to get issuer from well known endpoint";
-		  logger.error(errmsg, error);
-		  reject(errmsg);
-		} else if (body.issuer) {
-		  logger.debug("Got ISSUER from well known endpoint: " + body.issuer);
-		  serviceConfig.setIssuer(body.issuer);
-		  resolve(body.issuer);
-		} else {
-		  const errmsg = "Failed to get issuer from well known endpoint, missing issuer field.";
-		  logger.error(errmsg);
-		  reject(errmsg);
-		}
-	  });
+		(async () => {
+			try {
+				const reqParameters = {
+					responseType: 'json',
+					timeout: TIMEOUT,
+				}
+				const response = await got(wellKnownEndpoint, reqParameters);
+				const body = response.body && JSON.parse(response.body);
+
+				if (response.statusCode !== 200) {
+					HandleError(body?.error_description);
+				}
+				else if (body.issuer) {
+					logger.debug("Got ISSUER from well known endpoint: " + body.issuer);
+					serviceConfig.setIssuer(body.issuer);
+					resolve(body.issuer);
+				}
+				else {
+					const errmsg = "Failed to get issuer from well known endpoint, missing issuer field.";
+					logger.error(errmsg);
+					reject(errmsg);
+				}
+			} catch (err) {
+				HandleError(err);
+			}
+
+			function HandleError(error = '') {
+				const errmsg = "Failed to get issuer from well known endpoint";
+				logger.error(errmsg, error);
+				reject(errmsg);
+			}
+		})();
 	});
   }
   

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -18,6 +18,7 @@ const Q = require("q");
 const log4js = require("log4js");
 const publicKeyUtil = require("./public-key-util");
 const constants = require("./constants");
+const { parseJSON } = require('./common-util');
 
 const logger = log4js.getLogger("appid-token-util");
 const TIMEOUT = 15 * 1000;//15 seconds
@@ -97,9 +98,9 @@ module.exports = (function () {
 					timeout: TIMEOUT,
 				}
 				const response = await got(wellKnownEndpoint, reqParameters);
-				const body = response.body && JSON.parse(response.body);
+				const body = parseJSON(response.body);
 
-				if (response.statusCode !== 200) {
+				if (response.error || response.statusCode !== 200) {
 					HandleError(body?.error_description);
 				}
 				else if (body.issuer) {

--- a/lib/utils/token-util.js
+++ b/lib/utils/token-util.js
@@ -101,7 +101,15 @@ module.exports = (function () {
 				const body = parseJSON(response.body);
 
 				if (response.error || response.statusCode !== 200) {
-					HandleError(body?.error_description);
+					if(response.error){
+						HandleError(response.error);
+					}
+					else if(body.error_description){
+						HandleError(body.error_description);
+					}
+					else {
+						HandleError();
+					}
 				}
 				else if (body.issuer) {
 					logger.debug("Got ISSUER from well known endpoint: " + body.issuer);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {
@@ -38,12 +38,13 @@
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
     "ejs": "^3.1.3",
+    "form-data": "^2.3.3",
+    "got": "^9.6.0",
     "helmet": "^3.23.3",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^3.0.6",
     "npm-check-updates": "^7.0.1",
     "q": "^1.5.1",
-    "request": "^2.88.2",
     "rsa-pem-from-mod-exp": "^0.8.4",
     "underscore": "^1.10.2"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
     "ejs": "^3.1.3",
-    "form-data": "^2.3.3",
     "got": "^9.6.0",
     "helmet": "^3.23.3",
     "jsonwebtoken": "^8.5.1",

--- a/test/common-util-test.js
+++ b/test/common-util-test.js
@@ -1,0 +1,50 @@
+/*
+ Copyright 2017 IBM Corp.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+const chai = require("chai");
+const assert = chai.assert;
+const expect = chai.expect;
+let commonUtil = require("../lib/utils/common-util");
+chai.use(require("chai-as-promised"));
+
+describe("/lib/utils/common-util", function () {
+	context('jsonToURLencodedForm', () => {
+		const formData = {
+			"grant_type": "urn:ibm:params:oauth:grant-type:apikey",
+			"apikey": "2hntsFCUIw1hgPp31iRjcYllURtWeelFBgHYm4-ol3XB"
+		}
+
+		const urlEncodedData = 'grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=2hntsFCUIw1hgPp31iRjcYllURtWeelFBgHYm4-ol3XB';
+
+        it('should successfully convert the formData to URLencoded format', () => {
+            expect(commonUtil.jsonToURLencodedForm(formData)).to.equal(urlEncodedData);
+        });
+    });
+	
+	context('parseJSON', () => {
+		const validStringJson = '{"name":"abod","age":28,"car":"ford"}';
+		const validJSON = {"name":"abod","age":28,"car":"ford"};
+		const htmlError = "<div>Internal Server Error</div>";
+
+        it('should successfully return parsed JSON', () => {
+            expect(commonUtil.parseJSON(validStringJson)).to.deep.equal(validJSON);
+        });
+        it('should return the exact JSON', () => {
+            expect(commonUtil.parseJSON(validJSON)).to.deep.equal(validJSON);
+        });
+		
+		it('should return the exact text - Invalid JSON case', () => {
+            expect(commonUtil.parseJSON(htmlError)).to.deep.equal(htmlError);
+        });
+    });
+});

--- a/test/mocks/request-mock.js
+++ b/test/mocks/request-mock.js
@@ -1,91 +1,144 @@
 const previousAccessToken = "test.previousAccessToken.test";
+const { parseJSON } = require('../../lib/utils/common-util');
 
-module.exports = function (options, callback) {
-	if (options.formData && options.formData.grant_type === "refresh_token") {
-		if (options.formData.refresh_token === "WORKING_REFRESH_TOKEN") {
-			return callback(null, {statusCode: 200}, JSON.stringify({
+module.exports = function (reqUrl, reqParameters) {
+	const reqBody = parseJSON(reqParameters.body || '');
+	if (reqBody && reqBody.grant_type === "refresh_token") {
+		if (reqBody.refresh_token === "WORKING_REFRESH_TOKEN") {
+			return { 
+				statusCode: 200, 
+				body: JSON.stringify({
+					"access_token": "access_token_mock",
+					"id_token": "id_token_mock",
+					"refresh_token": "refresh_token_mock"
+				})
+			};
+		}
+		if (reqBody.refresh_token === "INVALID_REFRESH_TOKEN") {
+			return { 
+				statusCode: 401, 
+				body: JSON.stringify({
+					error: "invalid_grant",
+					"error_description": "invalid grant"
+				})
+			};
+		}
+	}
+	if (reqUrl.indexOf("generate_code") >= 0) {
+		if (reqParameters.headers.Authorization.indexOf("error") >= 0) {
+			return { 
+				statusCode: 0, 
+				error: new Error("STUBBED_ERROR")
+			};
+		}
+		if (reqParameters.headers.Authorization.indexOf("statusNot200") >= 0) {
+			return { 
+				statusCode: 400, 
+				body: null
+			};
+		}
+		return { 
+			statusCode: 200, 
+			body: "1234"
+		};
+	}
+	if (reqUrl.indexOf("FAIL-PUBLIC-KEY") >= 0 || reqUrl.indexOf("FAIL_REQUEST") >= 0) { // Used in public-key-util-test
+		return { 
+			statusCode: 0, 
+			error: new Error("STUBBED_ERROR")
+		};
+	} else if (reqUrl.indexOf("SUCCESS-PUBLIC-KEY") !== -1) { // Used in public-key-util-test
+		return { 
+			statusCode: 200, 
+			body: {"n": 1, "e": 2}
+		};
+	} else if (reqBody && reqBody.code && reqBody.code.indexOf("FAILING_CODE") !== -1) { // Used in webapp-strategy-test
+		return { 
+			statusCode: 0, 
+			error: new Error("STUBBED_ERROR")
+		};
+	} else if (reqBody && reqBody.code && reqBody.code.indexOf("WORKING_CODE") !== -1) { // Used in webapp-strategy-test
+		return { 
+			statusCode: 200, 
+			body: JSON.stringify({
 				"access_token": "access_token_mock",
 				"id_token": "id_token_mock",
 				"refresh_token": "refresh_token_mock"
-			}));
-		}
-		if (options.formData.refresh_token === "INVALID_REFRESH_TOKEN") {
-			return callback(null, {statusCode: 401}, JSON.stringify({
-				error: "invalid_grant",
-				"error_description": "invalid grant"
-			}));
-		}
-	}
-	if (options.url.indexOf("generate_code") >= 0) {
-		if (options.auth.bearer.indexOf("error") >= 0) {
-			return callback(new Error("STUBBED_ERROR"), {statusCode: 0}, null);
-		}
-		if (options.auth.bearer.indexOf("statusNot200") >= 0) {
-			return callback(null, {statusCode: 400}, null);
-		}
-		return callback(null, {statusCode: 200}, "1234");
-	}
-	if (options.url.indexOf("FAIL-PUBLIC-KEY") >= 0 || options.url.indexOf("FAIL_REQUEST") >= 0) { // Used in public-key-util-test
-		return callback(new Error("STUBBED_ERROR"), {statusCode: 0}, null);
-	} else if (options.url.indexOf("SUCCESS-PUBLIC-KEY") !== -1) { // Used in public-key-util-test
-		return callback(null, {statusCode: 200}, {"n": 1, "e": 2});
-	} else if (options.formData && options.formData.code && options.formData.code.indexOf("FAILING_CODE") !== -1) { // Used in webapp-strategy-test
-		return callback(new Error("STUBBED_ERROR"), {statusCode: 0}, null);
-	} else if (options.formData && options.formData.code && options.formData.code.indexOf("WORKING_CODE") !== -1) { // Used in webapp-strategy-test
-		return callback(null, {statusCode: 200}, JSON.stringify({
-			"access_token": "access_token_mock",
-			"id_token": "id_token_mock",
-			"refresh_token": "refresh_token_mock"
-		}));
-	} else if (options.followRedirect === false) {
-		return callback(null, {
+			})
+		};
+	} else if (reqParameters.followRedirect === false) {
+		return { 
 			statusCode: 302,
 			headers: {
 				location: "test-location?code=WORKING_CODE"
 			}
-		});
-	} else if (options.formData && options.formData.code && options.formData.code.indexOf("NULL_ID_TOKEN") !== -1) {
-		return callback(null, {statusCode: 200}, JSON.stringify({
-			"access_token": "access_token_mock",
-			"id_token": "null_scope",
-			"refresh_token": "refresh_token_mock"
-		}));
-	} else if (options.formData.username === "test_username" && options.formData.password === "bad_password") {
-		return callback(null, {statusCode: 401}, JSON.stringify({
-			error: "invalid_grant",
-			"error_description": "wrong credentials"
-		}));
-	} else if (options.formData.username === "request_error") {
-		return callback(new Error("REQUEST_ERROR"), {statusCode: 0}, null);
-	} else if (options.formData.username === "parse_error") {
-		return callback(null, {statusCode: 401}, JSON.stringify({
-			error: "invalid_grant",
-			"error_description": "wrong credentials"
-		}) + "dddddd");
-	} else if (options.formData.username === "test_username" && options.formData.password === "good_password") {
-		if (options.formData.scope) {
-			return callback(null, {statusCode: 200}, JSON.stringify({
-				"access_token": "access_token_mock_test_scope",
-				"id_token": "id_token_mock_test_scope",
-				"refresh_token": "refrehs_token_test_scope"
-			}));
+		};
+	} else if (reqBody && reqBody.code && reqBody.code.indexOf("NULL_ID_TOKEN") !== -1) {
+		return { 
+			statusCode: 200,
+			body: JSON.stringify({
+				"access_token": "access_token_mock",
+				"id_token": "null_scope",
+				"refresh_token": "refresh_token_mock"
+			})
+		};
+	} else if (reqBody.username === "test_username" && reqBody.password === "bad_password") {
+		return { 
+			statusCode: 401,
+			body: JSON.stringify({
+				error: "invalid_grant",
+				"error_description": "wrong credentials"
+			})
+		};
+	} else if (reqBody.username === "request_error") {
+		return { 
+			statusCode: 0,
+			error: new Error("REQUEST_ERROR")
+		};
+	} else if (reqBody.username === "parse_error") {
+		return { 
+			statusCode: 401,
+			body: JSON.stringify({
+				error: "invalid_grant",
+				"error_description": "wrong credentials"
+			}) + "dddddd"
+		};
+	} else if (reqBody.username === "test_username" && reqBody.password === "good_password") {
+		if (reqBody.scope) {
+			return { 
+				statusCode: 200,
+				body: JSON.stringify({
+					"access_token": "access_token_mock_test_scope",
+					"id_token": "id_token_mock_test_scope",
+					"refresh_token": "refrehs_token_test_scope"
+				})
+			};
 		}
-		if (options.formData.appid_access_token) {
-			if (options.formData.appid_access_token === previousAccessToken) {
-				return callback(null, {statusCode: 200}, JSON.stringify({
-					"access_token": "access_token_mock",
-					"id_token": "id_token_mock",
-					"previousAccessToken": previousAccessToken,
-					"refresh_token": "refresh_token_mock"
-				}));
+		if (reqBody.appid_access_token) {
+			if (reqBody.appid_access_token === previousAccessToken) {
+				return { 
+					statusCode: 200,
+					body: JSON.stringify({
+						"access_token": "access_token_mock",
+						"id_token": "id_token_mock",
+						"previousAccessToken": previousAccessToken,
+						"refresh_token": "refresh_token_mock"
+					})
+				};
 			}
-			return callback(null, {statusCode: 400}, {});
+			return { 
+				statusCode: 400,
+				body: {}
+			};
 		}
-		return callback(null, {statusCode: 200}, JSON.stringify({
-			"access_token": "access_token_mock",
-			"id_token": "id_token_mock",
-			"refresh_token": "refresh_token_mock"
-		}));
+		return { 
+			statusCode: 200,
+			body: JSON.stringify({
+				"access_token": "access_token_mock",
+				"id_token": "id_token_mock",
+				"refresh_token": "refresh_token_mock"
+			})
+		};
 	}
 
 	throw "Unhandled case!!!" + JSON.stringify(options);

--- a/test/mocks/request-mock.js
+++ b/test/mocks/request-mock.js
@@ -141,5 +141,5 @@ module.exports = function (reqUrl, reqParameters) {
 		};
 	}
 
-	throw "Unhandled case!!!" + JSON.stringify(options);
+	throw "Unhandled case!!!" + JSON.stringify(reqParameters);
 };

--- a/test/public-key-util-test.js
+++ b/test/public-key-util-test.js
@@ -59,6 +59,20 @@ describe("/lib/utils/public-key-util", function () {
 			});
 		});
 		
+		it("request to public keys endpoint failure - response body undefined", function (done) {
+			var kid = "not_found_kid";
+			PublicKeyUtil.getPublicKeyPemByKid(kid, testServerUrl + "KEYS-UNDEFINED").then(function () {
+				done("should get reject");
+			}).catch(function (err) {
+				try {
+					assert.equal(err, "updatePublicKeys error: Failed to retrieve public keys.  All requests to protected endpoints will be rejected.");
+					done();
+				} catch(e) {
+					done(e);
+				}
+			});
+		});
+		
 		it("request to public keys endpoint update failure", function (done) {
 			var kid = "123";
 			PublicKeyUtil.getPublicKeyPemByKid(kid, testServerUrl + "SUCCESS-PUBLIC-KEYs").then(function () {
@@ -147,6 +161,8 @@ var requestMock = function (reqUrl, reqParameters) {
 		return { statusCode: 0, body: new Error("STUBBED_ERROR")};
 	} else if (reqUrl.indexOf("SUCCESS-PUBLIC-KEY") !== -1) { // Used in public-key-util-test
 		return {statusCode: 200, body: {"keys": [{"n": "1", "e": "2", "kid": "123"}]}};
+	} else if (reqUrl.indexOf("KEYS-UNDEFINED") !== -1) { // Used in public-key-util-test
+		return {statusCode: 200};
 	} else if (reqParameters.formData && reqParameters.formData.code && reqParameters.formData.code.indexOf("FAILING_CODE") !== -1) { // Used in webapp-strategy-test
 		return { statusCode: 0, body: new Error("STUBBED_ERROR")};
 	} else if (reqParameters.formData && reqParameters.formData.code && reqParameters.formData.code.indexOf("WORKING_CODE") !== -1) { // Used in webapp-strategy-test

--- a/test/self-service-manager-test.js
+++ b/test/self-service-manager-test.js
@@ -13,6 +13,7 @@
 "use strict";
 const chai = require("chai");
 const assert = chai.assert;
+const expect = chai.expect;
 const rewire = require("rewire");
 const _ = require("underscore");
 const Q = require("q");
@@ -1273,6 +1274,7 @@ describe("/lib/self-service/self-service-manager", function () {
 		let netError = "netError";
 		let badInputError = "badInputError";
 		let badInputErrorBodyString = "badInputErrorBodyString";
+		let badInputErrorBodyJSON = {err: "some error string"};
 		let badInputErrorBodyWithDetail = "badInputErrorBodyWithDetail";
 		let badInputErrorBodyWithMessage = "badInputErrorBodyWithMessage";
 		let testApiKey = "testApiKey";
@@ -1342,6 +1344,16 @@ describe("/lib/self-service/self-service-manager", function () {
 					body: inputErrorBodyString
 				};
 			}
+			
+			if (reqUrl === badInputErrorBodyJSON) {
+				return { 
+					statusCode: 400, 
+					body: {
+						err: 	inputErrorBodyString
+					}
+				};
+			}
+
 			if (reqUrl === badInputErrorBodyWithDetail) {
 				return { 
 					statusCode: 400, 
@@ -1461,6 +1473,23 @@ describe("/lib/self-service/self-service-manager", function () {
 				}
 			};
 			_handleRequest(testToken, method, badInputErrorBodyString, body, queryObject , action, deferred);
+		});
+		
+		it("request failure bad input - body is NOT string", function (done) {
+			let deferred = {
+				resolve: function (body) {
+					done("should reject");
+				},
+				reject: function (err) {
+					try{
+						expect(badInputErrorBodyJSON).to.deep.equal(JSON.parse(err.message));
+						done();
+					} catch(e) {
+						done(e);
+					}
+				}
+			};
+			_handleRequest(testToken, method, badInputErrorBodyJSON, body, queryObject , action, deferred);
 		});
 		
 		it("request failure bad input - body with detail", function (done) {

--- a/test/self-service-manager-test.js
+++ b/test/self-service-manager-test.js
@@ -1159,34 +1159,41 @@ describe("/lib/self-service/self-service-manager", function () {
 		let netErrorObject = new Error("network issue");
 		let inputErrorBody = {error: "some bad input"};
 		let expectedInput = {
-			url:  testUrl,
-			method: "POST",
 			headers: {
-				"Content-Type": "application/x-www-form-urlencoded",
-				"Accept": "application/json"
+				"Accept": "application/json",
+				"Content-Type": "application/x-www-form-urlencoded"
 			},
-			form : {
-				"grant_type":"urn:ibm:params:oauth:grant-type:apikey",
-				"apikey" : testApiKey
-			}
+			method: "POST",
+			body: 'grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey=testApiKey',
+			responseType:'json'
 		};
 		
-		let stubRequest = function (options, callback) {
-			if (options.url === netError) {
-				return callback(netErrorObject, {}, {});
+		let stubRequest = function (reqUrl, reqParameters) {
+			if (reqUrl === netError) {
+				return {
+					error: netErrorObject
+				};
 			}
-			if (options.url === badInputError) {
-				return callback(null, {statusCode: 400}, inputErrorBody);
+			if (reqUrl === badInputError) {
+				return { 
+					statusCode: 400, 
+					body: inputErrorBody
+				};
 			}
-			if (JSON.stringify(options) !== JSON.stringify(expectedInput)) {
-				return callback(error, {}, {});
+			if (JSON.stringify(reqParameters) !== JSON.stringify(expectedInput)) {
+				return { 
+					error
+				};
 			}
-			callback(null, {statusCode: 200}, JSON.stringify({"access_token": testToken}));
+			return { 
+				statusCode: 200, 
+				body: JSON.stringify({"access_token": testToken})
+			};
 			
 		};
 		before(function (done) {
 			_getIAMToken = SelfServiceManager.__get__("_getIAMToken");
-			stubRequestRevert = SelfServiceManager.__set__("request", stubRequest);
+			stubRequestRevert = SelfServiceManager.__set__("got", stubRequest);
 			done();
 		});
 		after(function (done) {
@@ -1284,55 +1291,82 @@ describe("/lib/self-service/self-service-manager", function () {
 		let stubRequestRevert;
 		
 		let expectedInput = {
-			url: testUrl,
+			headers: {
+				"Authorization": "Bearer " + testToken,
+				"Content-type":"application/json"
+			},
 			method: method,
-			qs: queryObject,
-			json: body,
-			headers: {
-				"Authorization": "Bearer " + testToken
-			}
-		};
-		let expectedInputForGet = {
-			url: testUrl,
-			method: "GET",
-			qs: queryObject,
 			json: true,
+			searchParams: queryObject,
+			responseType: "json",
+			body:{"t":"t"}
+		};
+
+		let expectedInputForGet = {
 			headers: {
 				"Authorization": "Bearer " + testToken
-			}
+			},
+			method: "GET",
+			json:true,
+			searchParams: queryObject,
+			json: true,
+			responseType:"json"
 		};
 		
-		let stubRequest = function (options, callback) {
-			if (options.method === "GET") {
-				if (JSON.stringify(options) !== JSON.stringify(expectedInputForGet)) {
-					return callback(error, {}, {});
+		let stubRequest = function (reqUrl, reqParameters) {
+			if (reqParameters.method === "GET") {
+				if (JSON.stringify(reqParameters) !== JSON.stringify(expectedInputForGet)) {
+					return {
+						error
+					};
 				}
-				return callback(null, {statusCode: 200}, successBody);
+				return { 
+					statusCode: 200, 
+					body: successBody
+				};
 			}
-			if (options.url === netError) {
-				return callback(netErrorObject, {}, {});
+			if (reqUrl === netError) {
+				return {
+					error: netErrorObject
+				};
 			}
-			if (options.url === badInputError) {
-				return callback(null, {statusCode: 400}, inputErrorBody);
+			if (reqUrl === badInputError) {
+				return { 
+					statusCode: 400, 
+					body: inputErrorBody
+				};
 			}
-			if (options.url === badInputErrorBodyString) {
-				return callback(null, {statusCode: 400}, inputErrorBodyString);
+			if (reqUrl === badInputErrorBodyString) {
+				return { 
+					statusCode: 400, 
+					body: inputErrorBodyString
+				};
 			}
-			if (options.url === badInputErrorBodyWithDetail) {
-				return callback(null, {statusCode: 400}, inputErrorBodyDetail);
+			if (reqUrl === badInputErrorBodyWithDetail) {
+				return { 
+					statusCode: 400, 
+					body: inputErrorBodyDetail
+				};
 			}
-			if (options.url === badInputErrorBodyWithMessage) {
-				return callback(null, {statusCode: 400}, inputErrorBodyMessage);
+			if (reqUrl === badInputErrorBodyWithMessage) {
+				return { 
+					statusCode: 400, 
+					body: inputErrorBodyMessage
+				};
 			}
-			if (JSON.stringify(options) !== JSON.stringify(expectedInput)) {
-				return callback(error, {}, {});
+			if (JSON.stringify(reqParameters) !== JSON.stringify(expectedInput)) {
+				return { 
+					error
+				};
 			}
-			return callback(null, {statusCode: 200}, successBody);
-			
+			return { 
+				statusCode: 200, 
+				body: successBody
+			};
 		};
 		before(function (done) {
 			_handleRequest = SelfServiceManager.__get__("_handleRequest");
-			stubRequestRevert = SelfServiceManager.__set__("request", stubRequest);
+			stubRequestRevert = SelfServiceManager.__set__("got", stubRequest);
 			done();
 		});
 		after(function(done){

--- a/test/token-manager-test.js
+++ b/test/token-manager-test.js
@@ -168,6 +168,18 @@ describe('/lib/token-manager/token-manager', () => {
 			mockRetrieveTokenFailure(tokenManager, CUSTOM, 'Unexpected error', done);
 		});
 
+		it('Should FAIL to retrieve tokens', (done) => {
+			const tokenManager = new TokenManager();
+			tokenManager.getCustomIdentityTokens(mockJwsToken)
+				.then(() => {
+					done('suppose to fail');
+				})
+				.catch((error) => {
+					assert.equal(error.message, "Cannot read property 'body' of undefined");
+					done();
+				});
+		});
+		
 		it('Should retrieve tokens - Happy Flow', (done) => {
 			const tokenManager = new TokenManager(mockConfig(SUCCESS));
 			tokenManager.getCustomIdentityTokens(mockJwsToken)

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -24,14 +24,13 @@ describe("/lib/utils/token-util", function () {
   //let createDynamicIssuer=(endpoint)=>(_,cb)=>cb(undefined,{statusCode:200},{issuer:endpoint});
   let reqError;
   let resStatus = {statusCode: 200};
-  let reqEndpoint = "endpoint";
-  let resBody;
+  let resBody = { "body":{issuer: "endpoint"} };
+  let serviceFailure = false;
 
   function requestMock() {
-	  if(resBody === 'undefined') {
+	  if(serviceFailure) {
 		throw new Error('Error thrown');
 	  } else {
-		  resBody = { "body":{issuer: reqEndpoint} };
 		  return {
 				"error": reqError,
 				...resBody,
@@ -249,7 +248,7 @@ describe("/lib/utils/token-util", function () {
 	});
 	
 	it("get issuer from well known", function (done) {
-	  reqEndpoint = "endpoint";
+	  resBody.body.issuer = "endpoint";
 	  const config = new Config({
 		tenantId: constants.TENANTID,
 		clientId: constants.CLIENTID,
@@ -269,7 +268,7 @@ describe("/lib/utils/token-util", function () {
 	});
 	
 	it("get issuer from well known different endpoint", function (done) {
-	  reqEndpoint = "endpoint2";
+	  resBody.body.issuer = "endpoint2";
 	  const config = new Config({
 		tenantId: constants.TENANTID,
 		clientId: constants.CLIENTID,
@@ -289,7 +288,7 @@ describe("/lib/utils/token-util", function () {
 	});
 	
 	it("get issuer from well known returned error", function (done) {
-	  reqEndpoint = "endpoint";
+	  resBody.body.issuer = "endpoint";
 	  reqError = new Error(":(");
 	  const config = new Config({
 		tenantId: constants.TENANTID,
@@ -312,7 +311,7 @@ describe("/lib/utils/token-util", function () {
 	});
 	
 	it("get issuer from well known returned status code!= 200", function (done) {
-	  reqEndpoint = "endpoint";
+	  resBody.body.issuer = "endpoint";
 	  reqError = undefined;
 	  resStatus = {statusCode: 404};
 	  const config = new Config({
@@ -337,7 +336,7 @@ describe("/lib/utils/token-util", function () {
 	
 
 	it("get issuer from well known - response body undefined", function (done) {
-		resBody = 'undefined';
+		serviceFailure = true;
 		const config = new Config({
 		  tenantId: constants.TENANTID,
 		  clientId: constants.CLIENTID,
@@ -350,14 +349,16 @@ describe("/lib/utils/token-util", function () {
 		  
 		  TokenUtil.validateIssAndAud(decodedToken, config).then(() => {
 			done('This test should fail.');
+			serviceFailure = false;
 		  }).catch(err => {
 			  done();
+			  serviceFailure = false;
 		  });
 		});
 	  });
 	
 	it("get issuer from well known missing issuer", function (done) {
-	  reqEndpoint = undefined;
+	  resBody.body.issuer = undefined;
 	  reqError = undefined;
 	  resStatus = {statusCode: 200};
 	  const config = new Config({
@@ -373,15 +374,17 @@ describe("/lib/utils/token-util", function () {
 		TokenUtil.validateIssAndAud(decodedToken, config).then(() => {
 		  done("suppose to fail");
 		  reqError = undefined;
+		  resBody.body["issuer"] = "endpoint";
 		}).catch(() => {
 		  done();
 		  reqError = undefined;
+		  resBody.body["issuer"] = "endpoint";
 		});
 	  });
 	});
 	
 	it("don't go to issuer endpoint when issuer exists", function (done) {
-	  reqEndpoint = "endpoint2";
+	  resBody.body.issuer = "endpoint2";
 	  resStatus = {statusCode: 200};
 	  reqError = undefined;
 	  const config = new Config({

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -22,15 +22,17 @@ describe("/lib/utils/token-util", function () {
   console.log("Loading token-util-test.js");
   let TokenUtil;
   //let createDynamicIssuer=(endpoint)=>(_,cb)=>cb(undefined,{statusCode:200},{issuer:endpoint});
-  let reqEndpoint = "endpoint";
   let reqError;
-  let reqresponse = {statusCode: 200};
+  let resStatus = {statusCode: 200};
+  let reqEndpoint = "endpoint";
+  let resBody = { "body":{issuer: reqEndpoint} };
 
   function requestMock() {
+	resBody = { "body":{issuer: reqEndpoint} };
 		return {
 			"error": reqError,
-			"body": {issuer: reqEndpoint},
-			...reqresponse
+			...resBody,
+			...resStatus
 		}
   }
   let utilsStub = {
@@ -255,9 +257,9 @@ describe("/lib/utils/token-util", function () {
 		decodedToken.iss = "endpoint";
 		
 		TokenUtil.validateIssAndAud(decodedToken, config).then(() => {
-		  done();
+			done();
 		}).catch(err => {
-		  done(err);
+			done(err);
 		});
 	  });
 	});
@@ -308,7 +310,7 @@ describe("/lib/utils/token-util", function () {
 	it("get issuer from well known returned status code!= 200", function (done) {
 	  reqEndpoint = "endpoint";
 	  reqError = undefined;
-	  reqresponse = {statusCode: 404};
+	  resStatus = {statusCode: 404};
 	  const config = new Config({
 		tenantId: constants.TENANTID,
 		clientId: constants.CLIENTID,
@@ -329,10 +331,31 @@ describe("/lib/utils/token-util", function () {
 	  });
 	});
 	
+
+	it("get issuer from well known - response body undefined", function (done) {
+		resBody = undefined;
+		const config = new Config({
+		  tenantId: constants.TENANTID,
+		  clientId: constants.CLIENTID,
+		  secret: "secret",
+		  oauthServerUrl: "http://mobileclientaccess/",
+		  redirectUri: "redirectUri"
+		});
+		TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
+		  decodedToken.iss = "endpoint";
+		  
+		  TokenUtil.validateIssAndAud(decodedToken, config).then(() => {
+			done('This test should fail.');
+		  }).catch(err => {
+			  done();
+		  });
+		});
+	  });
+	
 	it("get issuer from well known missing issuer", function (done) {
 	  reqEndpoint = undefined;
 	  reqError = undefined;
-	  reqresponse = {statusCode: 200};
+	  resStatus = {statusCode: 200};
 	  const config = new Config({
 		tenantId: constants.TENANTID,
 		clientId: constants.CLIENTID,
@@ -355,7 +378,7 @@ describe("/lib/utils/token-util", function () {
 	
 	it("don't go to issuer endpoint when issuer exists", function (done) {
 	  reqEndpoint = "endpoint2";
-	  reqresponse = {statusCode: 200};
+	  resStatus = {statusCode: 200};
 	  reqError = undefined;
 	  const config = new Config({
 		tenantId: constants.TENANTID,

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -25,15 +25,19 @@ describe("/lib/utils/token-util", function () {
   let reqError;
   let resStatus = {statusCode: 200};
   let reqEndpoint = "endpoint";
-  let resBody = { "body":{issuer: reqEndpoint} };
+  let resBody;
 
   function requestMock() {
-	resBody = { "body":{issuer: reqEndpoint} };
-		return {
-			"error": reqError,
-			...resBody,
-			...resStatus
-		}
+	  if(resBody === 'undefined') {
+		throw new Error('Error thrown');
+	  } else {
+		  resBody = { "body":{issuer: reqEndpoint} };
+		  return {
+				"error": reqError,
+				...resBody,
+				...resStatus
+			}
+	  }
   }
   let utilsStub = {
 	"./public-key-util": require("./mocks/public-key-util-mock"),
@@ -333,7 +337,7 @@ describe("/lib/utils/token-util", function () {
 	
 
 	it("get issuer from well known - response body undefined", function (done) {
-		resBody = undefined;
+		resBody = 'undefined';
 		const config = new Config({
 		  tenantId: constants.TENANTID,
 		  clientId: constants.CLIENTID,

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -24,13 +24,13 @@ describe("/lib/utils/token-util", function () {
   //let createDynamicIssuer=(endpoint)=>(_,cb)=>cb(undefined,{statusCode:200},{issuer:endpoint});
   let reqEndpoint = "endpoint";
   let reqError;
-  
+  let reqresponse = {statusCode: 200};
 
   function requestMock() {
 		return {
 			"error": reqError,
 			"body": {issuer: reqEndpoint},
-			statusCode: 200,
+			...reqresponse
 		}
   }
   let utilsStub = {
@@ -319,28 +319,6 @@ describe("/lib/utils/token-util", function () {
 	  TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
 		decodedToken.iss = "endpoint";
 		
-		TokenUtil.validateIssAndAud(decodedToken, config).then(() => {
-		  done("suppose to fail");
-		  reqError = undefined;
-		}).catch(() => {
-		  done();
-		  reqError = undefined;
-		});
-	  });
-	});
-	it("get issuer from well known returned status code!= 200", function (done) {
-	  reqEndpoint = "endpoint";
-	  reqError = undefined;
-	  reqresponse = {statusCode: 404};
-	  const config = new Config({
-		tenantId: constants.TENANTID,
-		clientId: constants.CLIENTID,
-		secret: "secret",
-		oauthServerUrl: "http://mobileclientaccess/",
-		redirectUri: "redirectUri"
-	  });
-	  TokenUtil.decodeAndValidate(constants.ACCESS_TOKEN).then(function (decodedToken) {
-		decodedToken.iss = "endpoint";
 		TokenUtil.validateIssAndAud(decodedToken, config).then(() => {
 		  done("suppose to fail");
 		  reqError = undefined;

--- a/test/token-util-test.js
+++ b/test/token-util-test.js
@@ -24,12 +24,19 @@ describe("/lib/utils/token-util", function () {
   //let createDynamicIssuer=(endpoint)=>(_,cb)=>cb(undefined,{statusCode:200},{issuer:endpoint});
   let reqEndpoint = "endpoint";
   let reqError;
-  let reqresponse = {statusCode: 200};
   
+
+  function requestMock() {
+		return {
+			"error": reqError,
+			"body": {issuer: reqEndpoint},
+			statusCode: 200,
+		}
+  }
   let utilsStub = {
 	"./public-key-util": require("./mocks/public-key-util-mock"),
-	"request": (_, cb) => cb(reqError, reqresponse, {issuer: reqEndpoint})
-  };
+	"got": requestMock
+	}
   let Config;
   
   before(function () {

--- a/test/user-profile-manager-test.js
+++ b/test/user-profile-manager-test.js
@@ -20,25 +20,29 @@ const Q = require("q");
 const identityTokenSubIsSubject123 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpPU0UifQ.eyJzdWIiOiJzdWJqZWN0MTIzIn0.QpodAz7eU9NU0gBu0oj4zaI0maa94jzbm4BEV2I_sURw9fvfpLLt3zxHi-C3ItlcHiMSyWWL6oGyrkX_25Z7GK2Taxx5ix4bsi-iYOzJQ-SP4sVaKJ5fRMLMpnRMwOQrOGmrzhf53mqVJ76XK58ZM0Sa7pxM92N1PQDxPXPSfxejhN2xISi-Zw4yotQCny-AGjj5xnfNAPiaYjVGy_xK3Y_8xTSZkGcjuJ76deK9SBf7u-wH92zWWhqtaN_mU4yAOyejG3Z1aSduWc-N6K7jhjMReJLowJChDN2hCmvJ5EISL7JkITmZWdrQW-ZSZ76JMQ0u_-ecnX6r_C4KG_fzDg";
 const identityTokenSubIs123 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpPU0UifQ.eyJzdWIiOiIxMjMifQ.enbXHtja8BJd9_hlIbCgwyMXl8o9s74yDlqH4_11h7xLVasDO8Yy4jNyhVmIIb8jpl4fQfjWjqaOJoD2TqgfhqwQ-tGRjzYYR-f0qAMb99pNDtLS9IFf1yHYM2y65UerZ8qTD4g2s-ZWPk7yvxPMQx-Nrvu-X2uUwvdBCBr02rXpsHdMbeLYA6iwUs58p5hMxOxf3yKrBcTpTJ4EE164BhruEU5HyHhqSM9DTVLvliuapFFIK4CGV3FjvrKnT38yWdxSWtd9ETC79bfBwWTsE0ykMzb7Nq3vA2O0C_pv5IUixkLtTCiT3s5m55WZaqxdFCvOe4BjAt6AWH7slwgZdg";
 
-function requestMock(options, callback) {
-	var authHeader = options.headers["Authorization"];
+function requestMock(reqUrl, reqParameters) {
+	var authHeader = reqParameters.headers["Authorization"];
 
 	if (authHeader.indexOf("return_error") > 0) {
-		return callback(new Error("EXPECTED FAILURE"));
+		return {
+			error: new Error("EXPECTED FAILURE")
+		};
 	} else if (authHeader.indexOf("return_code") > 0) {
 		var statusCode = parseInt(authHeader.split("_")[2]);
-		return callback(null, {
+		return {
 			statusCode: parseInt(statusCode)
-		});
+		};
 	} else if (authHeader.indexOf("userinfo_access_token") > 0) {
-		options.sub = "123";
-		return callback(null, {
-			statusCode: 200
-		}, JSON.stringify(options));
+		reqParameters.sub = "123";
+		return {
+			statusCode: 200, 
+			body: JSON.stringify(reqParameters)
+		};
 	} else {
-		return callback(null, {
-			statusCode: 200
-		}, JSON.stringify(options));
+		return {
+			statusCode: 200, 
+			body: JSON.stringify(reqParameters)
+		};
 	}
 }
 
@@ -48,7 +52,7 @@ describe("/lib/user-profile-manager/user-profile-manager", function () {
 
 	before(function () {
 		UserProfileManager = proxyquire("../lib/user-profile-manager/user-profile-manager", {
-			"request": requestMock
+			"got": requestMock
 		});
 	});
 

--- a/test/webapp-strategy-test.js
+++ b/test/webapp-strategy-test.js
@@ -27,7 +27,7 @@ describe("/lib/strategies/webapp-strategy", function () {
 	before(function () {
 		WebAppStrategy = proxyquire("../lib/strategies/webapp-strategy", {
 			"../utils/token-util": tokenUtilsMock,
-			"request": require("./mocks/request-mock")
+			"got": require("./mocks/request-mock")
 		});
 		webAppStrategy = new WebAppStrategy({
 			tenantId: "tenantId",


### PR DESCRIPTION
Since the announcement of the request library going into "maintenance mode" (full details in [#3142](https://github.com/request/request/issues/3142)), Therefore I migrated the Request library to [GotJS](https://github.com/sindresorhus/got)