### PR TITLE
Fix: existing tag not recognised

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,3 @@
+{
+    "tagFormat": "${version}"
+}


### PR DESCRIPTION
By default, the tag format that semantic-release looks for is v${version}. So it will recognise "v6.2.0" but not “6.2.0". Without the prefix of “v“,  semantic-release could not find the existing versions. So this solution will configure the tagFormat to match our existing format