### PR TITLE
fix: Add missing form-data dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
     "ejs": "^3.1.3",
+    "form-data": "^4.0.0",
     "got": "^9.6.0",
     "helmet": "^3.23.3",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
The `form-data` package is referenced in source code, but it's not present in `package.json`. As a result it's not getting installed if `appid-serversdk-nodejs` is the only consumer of it, which leads to the crash. 

As a fix, I've added `form-data` as a direct dependency of the package.