### PR TITLE
fix: Add missing form-data dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
     "ejs": "^3.1.3",
-    "form-data": "^4.0.0",
+    "form-data": "^2.3.3",
     "got": "^9.6.0",
     "helmet": "^3.23.3",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
Added `form-data` as a direct dependency of the package.