### PR TITLE
fix(request-util.js): handle boolean values for `json` param in Request Utils

### DIFF
--- a/lib/utils/request-util.js
+++ b/lib/utils/request-util.js
@@ -83,19 +83,34 @@ module.exports = (function () {
                     delete options.formData;
                 }
 
+                // receive a JSON body 
+                // This is necessary for the ServerSDK only as we are expecting JSON response in all the calls 
+                options.responseType = 'json';
+
                 if (options.json) {
-                    options.body = JSON.stringify(options.json);
+                    // Handle json param same as Request library used to handle, so If json is true, then body must be a JSON-serializable object.
+                    if(typeof options.json == "boolean") {
+                        options.responseType = 'json';
+                    }
+                    // Handle json Request as Request library used to do, so If json is true, then body must be a JSON-serializable object.
+                    else {
+                        options.body = JSON.stringify(options.json);
+                    }
                     delete options.json;
+                }
+
+                // Handle json param same as Request library used to handle, so If json is false, then body must be Not a JSON-serializable object.
+                if (typeof options.json == "boolean" && !options.json) {
+                    delete options.json;
+                    delete options.responseType;
                 }
 
                 // requests that encounter an error status code will be resolved with the response instead of throwing
                 options.throwHttpErrors = false;
 
-                // receive a JSON body 
-                options.responseType = 'json';
-
                 // remove url from options 
                 const url = options.url;
+                delete options.url;
 
                 // Main Request Call
                 response = await got(url, options);

--- a/test/request-util-test.js
+++ b/test/request-util-test.js
@@ -40,7 +40,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                "url": 'sampleURL',
                 headers: {
                     "content-type": "application/json"
                 }
@@ -65,7 +64,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                "url": 'sampleURL',
                 headers: {
                     "content-type": "application/x-www-form-urlencoded"
                 }
@@ -89,7 +87,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                url: 'sampleURL',
                 searchParams: {
                     r: "r"
                 },
@@ -116,7 +113,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                url: 'sampleURL',
                 body: '{"r":"r"}',
                 headers: {
                     "content-type": "application/json"
@@ -146,7 +142,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                url: 'sampleURL',
                 body: jsonToURLencodedForm(sampleForm),
                 headers: {
                     "content-type": "application/x-www-form-urlencoded"
@@ -174,7 +169,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                url: 'sampleURL',
                 headers: {
                     "Authorization": `Bearer ${sampleToken}`,
                     "content-type": "application/json"
@@ -202,7 +196,6 @@ describe('/lib/utils/request-util', function (done) {
             }
 
             const expectedHeaders = {
-                url: 'sampleURL',
                 headers: {
                     "Authorization": "Basic " + Buffer.from(`${authUsername}:${authPassword}`).toString("base64"),
                     "content-type": "application/json"
@@ -225,7 +218,6 @@ describe('/lib/utils/request-util', function (done) {
         };
 
         const expectedHeaders = {
-            url: 'sampleURL',
             body: JSON.stringify(sampleForm),
             headers: {
                 "content-type": "application/json"


### PR DESCRIPTION
Fix the issue with the ServerSdK not handling `json` parameter as boolean after the migration RequestLibrary to GotJS.