### PR TITLE
fix(request-util.js): handle the Request Body for DELETE method

### DIFF
--- a/lib/utils/request-util.js
+++ b/lib/utils/request-util.js
@@ -41,11 +41,13 @@ module.exports = (function () {
 
                     options.headers = objectKeysToLowerCase(options.headers);
                     options.headers["content-type"] = options.headers["content-type"] || 'application/json';
-                } else {
+                } 
+                
+                // GotJS doesn't allow Request Body with the GET OR DELETE Method by default.
+                if(options.method === 'GET' || 'DELETE') {
                     if(options.body === null) {
                         delete options.body;
                     }
-                    // GotJS doesn't allow Request Body with the GET Method by default.
                     else {
                         options.allowGetBody = true;
                     }
@@ -132,7 +134,9 @@ module.exports = (function () {
                 callback(error, response, body);
             } catch (err) {
                 error = err;
-                statusCode = err.response.statusCode;
+                if (err.response && err.response.statusCode) {
+                    statusCode = err.response.statusCode;
+                }
 
                 // If body is empty, then return the response details of the error object
                 if(!body && err.response) {


### PR DESCRIPTION
GotJS doesn't allow passing Request body with GET methods by default, therefore we should handle the requests this way:
https://github.com/sindresorhus/got/pull/1081