### PR TITLE
Bump SDK Version Number to 6.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {


### PR DESCRIPTION
Bump SDK Version Number to 6.2.5 to [release the GotJS update from v9.6 to v11.8](https://github.com/ibm-cloud-security/appid-serversdk-nodejs/pull/263)