### PR TITLE
fix: 🐛 Bump GotJS from 11.8.3 to 11.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {
@@ -46,7 +46,7 @@
     "cookie-parser": "^1.4.5",
     "ejs": "^3.1.3",
     "form-data": "^2.3.3",
-    "got": "^11.8.3",
+    "got": "^11.8.5",
     "helmet": "^3.23.3",
     "jsonwebtoken": "^8.5.1",
     "log4js": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {


### PR DESCRIPTION
Bump GotJS from 11.8.3 to 11.8.5 to fix the following vulnerability: 
https://snyk.io/vuln/SNYK-JS-GOT-2932019