### PR TITLE
Use Passport v6.0.0

### DIFF
--- a/lib/strategies/webapp-strategy.js
+++ b/lib/strategies/webapp-strategy.js
@@ -146,6 +146,7 @@ WebAppStrategy.prototype.authenticate = function (req, options = {}) {
 		return this.redirect(url);
 	} else {
 		// Handle authorization request
+		options.keepSessionInfo = true;
 		return handleAuthorization(req, options, this);
 	}
 };
@@ -324,6 +325,7 @@ function handleCallback(req, options = {}, strategy) {
 	logger.debug("handleCallback");
 	options.failureRedirect = options.failureRedirect || "/";
 	options.successReturnToOrRedirect = "/"; // fallback to req.session.returnTo
+	options.keepSessionInfo = true;
 	const stateParameter = req.session[WebAppStrategy.STATE_PARAMETER];
 	// Check for handleChangeDetails, handleForgotPassword callback from cloud directory
 	const cloudDirectoryUpdate = req.session[WebAppStrategy.CLOUD_DIRECTORY_UPDATE_REQ];

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "express-session": "^1.17.1",
     "mocha": "^5.2.0",
     "nyc": "^15.0.0",
-    "passport": "^0.4.1",
+    "passport": "^0.6.0",
     "proxyquire": "^2.1.3",
     "rewire": "^4.0.1",
     "semantic-release": "^18.0.0",

--- a/samples/cloud-directory-app-sample-server.js
+++ b/samples/cloud-directory-app-sample-server.js
@@ -132,7 +132,7 @@ app.post(ROP_SUBMIT, function(req, res, next) {
 			req.flash('errorCode', info.code);
 			return res.redirect(ROP_LOGIN_PAGE_URL + languageQuery + emailInputQuery);
 		}
-		req.logIn(user, function (err) {
+		req.logIn(user, { keepSessionInfo: true }, function (err) {
 			if (err) {
 				return next(err);
 			}
@@ -237,11 +237,11 @@ app.post(CHANGE_DETAILS_SUBMIT, passport.authenticate(WebAppStrategy.STRATEGY_NA
 });
 
 // Logout endpoint. Clears authentication information from session
-app.get(LOGOUT_URL, function(req, res){
-	WebAppStrategy.logout(req);
-	res.redirect(LANDING_PAGE_URL);
+app.get(LOGOUT_URL, function (req, res){
+	req.session.destroy(function (err) {
+	  res.redirect(LANDING_PAGE_URL);
+	});
 });
-
 
 function _generateUserScim(body) {
 	let userScim = {};

--- a/samples/web-app-sample-server.js
+++ b/samples/web-app-sample-server.js
@@ -134,9 +134,10 @@ app.get(LOGIN_ANON_URL, passport.authenticate(WebAppStrategy.STRATEGY_NAME, {
 app.get(CALLBACK_URL, passport.authenticate(WebAppStrategy.STRATEGY_NAME));
 
 // Logout endpoint. Clears authentication information from session
-app.get(LOGOUT_URL, function (req, res) {
-	WebAppStrategy.logout(req);
-	res.redirect(LANDING_PAGE_URL);
+app.get(LOGOUT_URL, function (req, res){
+	req.session.destroy(function (err) {
+	  res.redirect(LANDING_PAGE_URL);
+	});
 });
 
 function storeRefreshTokenInCookie(req, res, next) {


### PR DESCRIPTION
Made changes to webAppStrategy to handle the regenerate function in Passport v6, Empty options, had been passed so session info was being reset Now passing the option keepSessionInfo = true
Made changes to sample applications