### PR TITLE
Add minimum node version to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "engines" : { 
+    "node" : ">=12.0.0"
   }
 }


### PR DESCRIPTION
Since the new version of `jsonwebtoken` requires a minimum of v12 Node therefore updating the `package.json` accordingly