### PR TITLE
fix(package.json): updating json webtoken to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.2.6",
+  "version": "6.2.7",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.2.7",
+  "version": "6.3.0",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmcloud-appid",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Node.js SDK for the IBM Cloud App ID service",
   "main": "lib/appid-sdk.js",
   "scripts": {
@@ -49,7 +49,7 @@
     "form-data": "^2.3.3",
     "got": "^11.8.5",
     "helmet": "^3.23.3",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "log4js": "^6.4.1",
     "tsd": "^0.20.0",
     "q": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "engines" : { 
+    "node" : ">=12.0.0"
   }
 }


### PR DESCRIPTION
The package uses jsonwebtoken 8.5.1 which is deprecated now and having security issues therefore updating to the patched
jsonwebtoken v9.0.0. 

The new version requires a minimum of v12 Node.

fix https://github.com/ibm-cloud-security/appid-serversdk-nodejs/issues/286
