### PR TITLE
Upgrade node to version 18 for the Github workflow jobs

### DIFF
--- a/.github/workflows/dry-publish.js.yml
+++ b/.github/workflows/dry-publish.js.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
The new version of Semantic Release requires Node version 18.

Error:
![image](https://user-images.githubusercontent.com/67692574/215801065-677bdfa0-ce55-48f9-9629-241eb5004557.png)
